### PR TITLE
New Sliders!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.7.9"
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -15,10 +16,11 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
+JSON = "^0.21.1"
 Reexport = "^1"
 Suppressor = "^0.2.0"
 julia = "^1"
-JSON = "^0.21.1"
+HypertextLiteral = "^0.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -33,8 +33,8 @@ function show(io::IO, mimetype::MIME"text/html", slider::Slider)
             let slider = parentnode.querySelector("input")
         
             slider.addEventListener("input", e => {
-                parentnode.value = +slider.value
-                $(JavaScript(show_value ? "parentnode.querySelector(\"output\").value = +slider.value" : ""))
+                parentnode.value = slider.valueAsNumber
+                $(JavaScript(show_value ? "parentnode.querySelector(\"output\").value = slider.valueAsNumber" : ""))
                 parentnode.dispatchEvent(new CustomEvent("input"))
                 e.preventDefault()
             })

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -20,7 +20,7 @@ Slider(range::AbstractRange; default=first(range), show_value=false) = @htl("""
 	
 	<script>
 		let div = currentScript.parentElement
-		var slider = div.querySelector("input")
+		let slider = div.querySelector("input")
 	
 		slider.addEventListener("input", e => {
 			div.value = +slider.value
@@ -30,11 +30,11 @@ Slider(range::AbstractRange; default=first(range), show_value=false) = @htl("""
 		})
 	
 		div.value = $(default)
-		var localVal = div.value
+		let localVal = div.value
 		delete div.value
 		Object.defineProperty(div, "value",
 			{configurable: false,
-    		enumerable: false,
+    			enumerable: false,
 			get: () => {return localVal},
 			set: (newVal) => {
 				slider.value = newVal

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -21,7 +21,7 @@ end
 """
 Slider(range::AbstractRange; default=first(range), show_value=false) = Slider(range, default, show_value)
 
-function show(io::IO, mimetype, slider::Slider)
+function show(io::IO, mimetype::MIME"text/html", slider::Slider)
     range, default, show_value = slider.range, slider.default, slider.show_value
     show(io, mimetype, @htl("""
     <span>

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -41,7 +41,6 @@ function show(io::IO, mimetype::MIME"text/html", slider::Slider)
         
             parentnode.value = $(default)
             let localVal = parentnode.value
-            delete parentnode.value
             Object.defineProperty(parentnode, "value",
                 {configurable: false,
                 enumerable: false,

--- a/src/PlutoUI.jl
+++ b/src/PlutoUI.jl
@@ -2,6 +2,7 @@ module PlutoUI
 
 import Base: show, get
 import Markdown: htmlesc, withtag
+import HypertextLiteral: @htl, JavaScript
 
 using Reexport
 


### PR DESCRIPTION
This reimplements Sliders solving two issues:

1. It starts on the proposed rewrite in `HypertextLiteral.jl` as stated in https://github.com/fonsp/PlutoUI.jl/pull/62 and https://github.com/fonsp/PlutoUI.jl/issues/59 .
2. This fixes a issue that with multiple of the same Slider with `show_value = true`, moving a Slider would only change the display of the various input ranges, but not the display of the value. This syncs all the values, solving https://github.com/fonsp/PlutoUI.jl/issues/96 .

Unfortunately, there is a slight caveat to consider. Traditionally, the Slider is seen as the "simplest" example of PlutoUI and a good way to introduce the ecosystem. However, this rewrite makes use of fairly nasty tricks to ensure (2) above. 