### PR TITLE
Adding convenience macro for `with_terminal`

### DIFF
--- a/src/Terminal.jl
+++ b/src/Terminal.jl
@@ -1,4 +1,4 @@
-export with_terminal
+export with_terminal, @terminal
 
 import Suppressor: @color_output, @capture_out, @capture_err
 import Logging:  ConsoleLogger, with_logger
@@ -80,4 +80,27 @@ function with_terminal(f::Function, args...; kwargs...)
 		end
   end
 	WithTerminalOutput(spam_out, spam_err, value)
+end
+
+"""
+A convenience macro for `with_terminal` calls. See usage below.
+			
+__Usage:__
+			
+```julia
+@terminal @show 2+2
+@terminal begin
+	println("2+2 = ", 2+2)
+	println("also...")
+	println("4+4 = ", 4+4)
+end
+@terminal print("Hello, world!")
+```
+"""
+macro terminal(expr)
+	quote
+		with_terminal() do
+			$(esc(expr))
+		end
+	end
 end


### PR DESCRIPTION
When I write Pluto notebooks, I nearly always write a cell with...

```julia
macro terminal(expr)	
  quote		
    with_terminal() do			
      $(esc(expr))		
    end	
  end
end
```

This way, to quickly show values I can simply write `@terminal print(my_struct)`. Replacing `print` with a block of `show` or `print` calls also works. 

This feels like a pretty unobtrusive addition, and I think it makes for a nice convenience wrapper for the `with_terminal` function. I figured I'd post it here in case it was useful. Feel free to toss this!