### PR TITLE
Re-adjusted ToC z-index

### DIFF
--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -147,7 +147,7 @@ const toc_css = """
 		/* That is, viewport minus top minus Live Docs */
 		max-height: calc(100vh - 5rem - 56px);
 		overflow: auto;
-		z-index: 20;
+		z-index: 40;
 		background: white;
 	}
 }


### PR DESCRIPTION
Table of contents "aside" panel was (again) appearing underneath the tan cells—related to: https://github.com/fonsp/Pluto.jl/issues/1538#issuecomment-962719019
