### PR TITLE
Doc fixes for pairs in Select/MultiSelect

### DIFF
--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -481,33 +481,34 @@ end
 begin
 	local result = begin
 	"""
-		Select(options; [default])
+	```julia
+	Select(options::Vector; [default])
+	# or with a custom display value:
+	Select(options::Vector{Pair{Any,String}}; [default::Any])
+	```
 
-	A dropdown menu (`<select>`) - the user can choose an element of the `options` vector.
-
-	`options` can also be an array of pairs `bound_value => display_value`. 
-	`bound_value` is returned via `@bind`; it is shown in the dropdown menu as `string(display_value)`.
+	A dropdown menu - the user can choose an element of the `options` vector.
 
 	See [`MultiSelect`](@ref) for a version that allows multiple selected items.
 
-
 	# Examples
-	`@bind veg Select(["potato", "carrot"])`
-
-	`@bind veg Select(["potato" => "🥔", "carrot" => "🥕"])`
+	```julia
+	@bind veg Select(["potato", "carrot"])
+	```
 	
-	`@bind veg Select(["potato" => "🥔", "carrot" => "🥕"], default="carrot")`
-
-	In all three cases, `veg` will be either `"potato"` or `"carrot"`.
+	```julia
+	@bind f Select([sin, cos, tan, sqrt])
 	
-	The *key* can be any object, like a string, number, or even a function:
+	f(0.5)
+	```
+
+	You can also specify a display value by giving pairs `bound_value => display_value`:
 	
 	```julia
 	@bind f Select([cos => "cosine function", sin => "sine function"])
 
 	f(0.5)
 	```
-
 	"""
 	struct Select
 		options::AbstractVector{Pair}

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -481,11 +481,15 @@ end
 begin
 	local result = begin
 	"""
-	A dropdown menu (`<select>`) - the user can choose one of the `options`, an array of `String`s.
+		Select(options; [default])
+
+	A dropdown menu (`<select>`) - the user can choose an element of the `options` vector.
+
+	`options` can also be an array of pairs `bound_value => display_value`. 
+	`bound_value` is returned via `@bind`; it is shown in the dropdown menu as `string(display_value)`.
 
 	See [`MultiSelect`](@ref) for a version that allows multiple selected items.
 
-	`options` can also be an array of pairs `key::Any => display_value::String`. The `key` is returned via `@bind`; the `display_value` is shown.
 
 	# Examples
 	`@bind veg Select(["potato", "carrot"])`
@@ -678,11 +682,15 @@ subarrays(x) = (
 # ╔═╡ 5bacf96d-f24b-4e8b-81c7-47140f286e27
 begin
 local result = begin
-	"""A multi-selector (`<select multi>`) - the user can choose one or more of the `options`, an array of `Strings.
+"""
+	MultiSelect(options; [default], [size])
+
+A multi-selector (`<select multi>`) - the user can choose one or more of the `options`.
 
 See [`Select`](@ref) for a version that allows only one selected item.
 
-`options` can also be an array of pairs `key::String => value::Any`. The `key` is returned via `@bind`; the `value` is shown.
+`options` can a vector, or an array of pairs `bound_value::AbstractString => display_value`. 
+`bound_value` is returned via `@bind`; it is shown in the widget as `string(display_value)`.
 
 The `size` keyword argument may be used to specify how many rows should be visible at once.
 


### PR DESCRIPTION
Clarify the docs and correct the types the `Select` and `MultiSelect` (I suspect there was some confusion in https://github.com/JuliaPluto/PlutoUI.jl/commit/18786e10f95e28a8f8cc299996291ff2a417d421 where `::String` was moved from key to value rather than being removed)