### PR TITLE
Make TableOfContents headers go to top of screen

### DIFF
--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -72,7 +72,7 @@ const render = (el) => html`\${el.map(h => {
 		e.preventDefault();
 		h.scrollIntoView({
 			behavior: 'smooth', 
-			block: 'center'
+			block: 'start'
 		})
 	}
 


### PR DESCRIPTION
Before this change, if you clicked on a heading in the TableOfContents, the page would navigate so that the selected heading was in the **centre** of the screen, which is a very behaviour and I find very difficult to adjust to. E.g. compare to how table of contents work in Wikipedia. 

Currently, when one clicks on the heading "Level 2" this is what you see. 
![image](https://user-images.githubusercontent.com/29157027/146092289-fceadd2c-b210-43cb-899d-8cead30dab7b.png)
This makes it quite difficult for the eye to quickly locate level 2 on the screen!

With this PR, you now instead see 
![image](https://user-images.githubusercontent.com/29157027/146092167-eef7ff31-03de-435d-b1ce-a627bb1ae0bf.png)

which is much easier to locate, because it's quite easy for the eye to estimate where the top of the page is, but not the middle (unless you have a guide rule across your screen). 