### PR TITLE
Move closing `>`s to previous lines.

### DIFF
--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -74,21 +74,19 @@ begin
 	OldSlider(range::AbstractRange; default=missing, show_value=false) = OldSlider(range, (default === missing) ? first(range) : default, show_value)
 	
 	function Base.show(io::IO, m::MIME"text/html", slider::OldSlider)
-		show(io, m, @htl("""
-				<input 
-				type="range" 
-				min=$(first(slider.range))
-				step=$(step(slider.range))
-				max=$(last(slider.range))
-
-				value=$(slider.default)
-				oninput=$(slider.show_value ? "this.nextElementSibling.value=this.value" : "")>
-
-				$(
-				slider.show_value ? @htl("<output>$(slider.default)</output>") : nothing
-				)
-				
-				"""))
+		show(io, m, 
+			@htl("""<input $((
+					type="range",
+					min=first(slider.range),
+					step=step(slider.range),
+					max=last(slider.range),
+					value=slider.default,
+					oninput=(slider.show_value ? "this.nextElementSibling.value=this.value" : ""),
+				))>$(
+					slider.show_value ? 
+						@htl("<output>$(slider.default)</output>") : 
+						nothing
+				)"""))
 	end
 
 	Base.get(slider::OldSlider) = slider.default
@@ -142,12 +140,12 @@ begin
 		start_index = findfirst(isequal(slider.default), slider.values)
 		
 		show(io, m, @htl(
-			"""<input 
-				type="range" 
-				min=1
-				max=$(length(slider.values))
-				value=$(start_index)>
-				$(
+			"""<input $((
+				type="range",
+				min=1,
+				max=length(slider.values),
+				value=start_index,
+			))>$(
 					slider.show_value ? @htl(
 					"""<script>
 					const input_el = currentScript.previousElementSibling
@@ -159,7 +157,7 @@ begin
 					})
 					</script><output>$(string(slider.default))</output>"""
 				) : nothing
-				)"""))
+			)"""))
 	end
 
 	Base.get(slider::Slider) = slider.default
@@ -205,8 +203,14 @@ begin
 	
 	NumberField(range::AbstractRange{<:T}; default=missing) where T = NumberField(range, (default === missing) ? first(range) : convert(T,default))
 	
-	function Base.show(io::IO, ::MIME"text/html", numberfield::NumberField)
-		print(io, """<input type="number" min="$(first(numberfield.range))" step="$(step(numberfield.range))" max="$(last(numberfield.range))" value="$(numberfield.default)">""")
+	function Base.show(io::IO, m::MIME"text/html", numberfield::NumberField)
+		show(io, m, @htl("""<input $((
+				type="number",
+				min=first(numberfield.range),
+				step=step(numberfield.range),
+				max=last(numberfield.range),
+				value=numberfield.default
+			))>"""))
 	end
 	
 	Base.get(numberfield::NumberField) = numberfield.default
@@ -307,8 +311,7 @@ begin
 	
 	function Base.show(io::IO, m::MIME"text/html", button::CounterButton)
 		show(io, m, @htl(
-			"""<span><input type="button" value="$(button.label)"
-			><script>
+			"""<span><input type="button" value=$(button.label)><script>
 		let count = 0
 		const span = currentScript.parentElement
 		const button = span.firstElementChild
@@ -608,13 +611,13 @@ function Base.show(io::IO, m::MIME"text/html", radio::Radio)
 		"""<form>$(
 		map(radio.options) do o
 			@htl(
-				"""<div><input 
-					type="radio" 
-					id=$(groupname * o.first) 
-					name=$(groupname) 
-					value=$(o.first)
-					checked=$(radio.default === o.first)
-					><label for=$(groupname * o.first)>$(
+				"""<div><input $((
+					type="radio",
+					id=(groupname * o.first),
+					name=groupname,
+					value=o.first,
+					checked=(radio.default === o.first),
+				))><label for=$(groupname * o.first)>$(
 					o.second
 				)</label></div>"""
 			)
@@ -659,6 +662,9 @@ Base.get(radio::Radio) = radio.default
 	end
 	result
 end
+
+# ╔═╡ 04ed1e71-d806-423e-b99c-476ea702feb3
+Radio(["a", "b"]; default="b")
 
 # ╔═╡ 7c4303a1-19be-41a2-a6c7-90146e01401d
 md"""
@@ -808,10 +814,10 @@ DateField
 	end
 
 function Base.show(io::IO, m::MIME"text/html", datefield::DateField)
-	show(io, m, @htl("""<input
-				type="date"
-				value=$(datefield.default === nothing ? "" : Dates.format(datefield.default, "Y-mm-dd"))>
-			"""))
+	show(io, m, @htl("<input $((
+			type="date",
+			value=(datefield.default === nothing ? "" : Dates.format(datefield.default, "Y-mm-dd")),
+		))>"))
 end
 Base.get(datefield::DateField) = datefield.default === nothing ? nothing : Dates.DateTime(datefield.default)
 	Bonds.initial_value(datefield::DateField) = 
@@ -843,12 +849,12 @@ TimeField
 end
 
 function Base.show(io::IO, m::MIME"text/html", timefield::TimeField)
-	show(io, m, @htl("<input
-		type='time'
-		value=$(
-			timefield.default === nothing ? nothing : Dates.format(timefield.default, "HH:MM")
-		)>
-	"))
+	show(io, m, @htl("<input $((
+			type="time",
+			value=(
+				timefield.default === nothing ? nothing : Dates.format(timefield.default, "HH:MM"),
+			)
+		))>"))
 end
 Base.get(timefield::TimeField) = timefield.default === nothing ?  "" : Dates.format(timefield.default, "HH:MM")
 	Bonds.initial_value(timefield::TimeField) = 
@@ -933,6 +939,15 @@ bos
 
 # ╔═╡ 05f6a603-b738-47b1-b335-acaaf480a240
 os1, os2, os3
+
+# ╔═╡ f7870d7f-992d-4d64-85aa-7621ab16244f
+nf1b = @bind nf1 NumberField(1:10)
+
+# ╔═╡ 893e22e1-a1e1-43cb-84fe-4931f3ba35c1
+nf1b
+
+# ╔═╡ 7089edb6-720d-4df5-b3ca-da17d48b107e
+nf1
 
 # ╔═╡ c6d68308-53e7-4c60-8649-8f0161f28d70
 @bind b1 Button(teststr)
@@ -1141,6 +1156,9 @@ export Slider, NumberField, Button, LabelButton, CounterButton, CheckBox, TextFi
 # ╠═629e5d68-580f-4d6b-be14-5a109091e6b7
 # ╠═05f6a603-b738-47b1-b335-acaaf480a240
 # ╟─f59eef32-4732-46db-87b0-3564433ce43e
+# ╠═f7870d7f-992d-4d64-85aa-7621ab16244f
+# ╠═893e22e1-a1e1-43cb-84fe-4931f3ba35c1
+# ╠═7089edb6-720d-4df5-b3ca-da17d48b107e
 # ╟─b7c21c22-17f5-44b8-98de-a261d5c7192b
 # ╠═7f8e4abf-e7e7-47bc-b1cc-514fa1af106c
 # ╠═c6d68308-53e7-4c60-8649-8f0161f28d70
@@ -1187,6 +1205,7 @@ export Slider, NumberField, Button, LabelButton, CounterButton, CheckBox, TextFi
 # ╠═f3bef89c-61ac-4dcf-bf47-3824f11db26f
 # ╟─42e9e5ab-7d34-4300-a6c0-47f5cde658d8
 # ╠═57232d88-b74f-4823-be61-8db450c93f5c
+# ╠═04ed1e71-d806-423e-b99c-476ea702feb3
 # ╟─7c4303a1-19be-41a2-a6c7-90146e01401d
 # ╠═a95684ea-4612-45d6-b63f-41c051b53ed8
 # ╠═a5612030-0781-4cf1-b8f0-409bd3886154

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -82,8 +82,7 @@ begin
 				max=$(last(slider.range))
 
 				value=$(slider.default)
-				oninput=$(slider.show_value ? "this.nextElementSibling.value=this.value" : "")
-				>
+				oninput=$(slider.show_value ? "this.nextElementSibling.value=this.value" : "")>
 
 				$(
 				slider.show_value ? @htl("<output>$(slider.default)</output>") : nothing
@@ -147,8 +146,8 @@ begin
 				type="range" 
 				min=1
 				max=$(length(slider.values))
-				value=$(start_index)
-				>$(
+				value=$(start_index)>
+				$(
 					slider.show_value ? @htl(
 					"""<script>
 					const input_el = currentScript.previousElementSibling
@@ -811,8 +810,8 @@ DateField
 function Base.show(io::IO, m::MIME"text/html", datefield::DateField)
 	show(io, m, @htl("""<input
 				type="date"
-				value=$(datefield.default === nothing ? "" : Dates.format(datefield.default, "Y-mm-dd"))
-			>"""))
+				value=$(datefield.default === nothing ? "" : Dates.format(datefield.default, "Y-mm-dd"))>
+			"""))
 end
 Base.get(datefield::DateField) = datefield.default === nothing ? nothing : Dates.DateTime(datefield.default)
 	Bonds.initial_value(datefield::DateField) = 
@@ -848,8 +847,8 @@ function Base.show(io::IO, m::MIME"text/html", timefield::TimeField)
 		type='time'
 		value=$(
 			timefield.default === nothing ? nothing : Dates.format(timefield.default, "HH:MM")
-		)
-	>"))
+		)>
+	"))
 end
 Base.get(timefield::TimeField) = timefield.default === nothing ?  "" : Dates.format(timefield.default, "HH:MM")
 	Bonds.initial_value(timefield::TimeField) = 


### PR DESCRIPTION
Noticed when trying out https://github.com/MichaelHatherly/CommonMark.jl/issues/31.

Some of the formatting of closing `>`s for the HTML tags put them on their own lines. The commonmark spec doesn't really like this, and instead parses the dangling `>` as the start of a quote block, which leaves the preceding HTML as raw text. This is pretty reasonable for the spec to do since markdown syntax has precedence over embedded HTML. All this PR does is move those `>`s to the previous line and things work out nicely.

Another more global change could be to have `@htl` do some minifying and strip out white space characters from it's output such that the user doesn't have to care about the white space sensitivity of embedded HTML in markdown.
