### PR TITLE
Fix ToC hover styling issue

### DIFF
--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -171,8 +171,8 @@ const toc_css = """
 @media (prefers-color-scheme: dark) {
 	.plutoui-toc {
 		--main-bg-color: hsl(0deg 0% 21%);
-		--pluto-output-color: hsl(0, 0%, 90%)
-		--pluto-output-h-color: hsl(0, 0%, 97%)
+		--pluto-output-color: hsl(0, 0%, 90%);
+		--pluto-output-h-color: hsl(0, 0%, 97%);
 	}
 }
 


### PR DESCRIPTION
There was a small problem with the CSS code for overriding the variables that change the link color attributes. In particular, `--pluto-output-h-color` was not getting overridden properly due to a few missing semicolons. All I've done in this PR is add those in, and the `:hover` behavior of ToC links now works properly.