### PR TITLE
Hide ToC contents when hidden

### DIFF
--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.0
+# v0.19.3
 
 using Markdown
 using InteractiveUtils
@@ -199,10 +199,10 @@ const toc_css = """
 	transform: translateX(calc(100% - 28px));
 }
 .plutoui-toc.aside.hide section {
-    	display: none;
+	display: none;
 }
 .plutoui-toc.aside.hide header {
-    	margin-bottom: 0em;
+	margin-bottom: 0em;
 	padding-bottom: 0em;
 	border-bottom: none;
 }

--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -197,7 +197,14 @@ const toc_css = """
 
 .plutoui-toc.aside.hide {
 	transform: translateX(calc(100% - 28px));
-	height: 57px;
+}
+.plutoui-toc.aside.hide section {
+    	display: none;
+}
+.plutoui-toc.aside.hide header {
+    	margin-bottom: 0em;
+	padding-bottom: 0em;
+	border-bottom: none;
 }
 }  /* End of Media print query */
 .plutoui-toc.aside.hide .open-toc,

--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -197,6 +197,7 @@ const toc_css = """
 
 .plutoui-toc.aside.hide {
 	transform: translateX(calc(100% - 28px));
+	height: 57px;
 }
 }  /* End of Media print query */
 .plutoui-toc.aside.hide .open-toc,


### PR DESCRIPTION
This very small change simply reduce the ToC height to only show the closed book icon when the ToC is hidden. 
This is done to minimize the vertical clutter of the ToC (now that the ToC does not remove its aside status automatically anymore) when the main text is very close to the edge of the browser.
See https://github.com/fonsp/Pluto.jl/issues/2093 for example.
 
New behavior example:
![89547624-f1ae-476c-91ba-297ce8e19e96](https://user-images.githubusercontent.com/12846528/166915143-ad952102-6a8f-420c-a4a5-24b35be6dbed.gif)

