### PR TITLE
Add method for generator given to Select

### DIFF
--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -598,6 +598,14 @@ begin
 
 	f(0.5)
 	```
+	
+	If a generator is given, it is automatically turned into a vector:
+	
+	```julia
+	@bind f Select(i for i in 1:10)
+	# is equivalent to
+	@bind f Select([i for i in 1:10])
+	```
 	"""
 	struct Select
 		options::AbstractVector{Pair}
@@ -608,6 +616,8 @@ begin
 	Select(options::AbstractVector; default=missing) = Select([o => o for o in options], default)
 	
 	Select(options::AbstractVector{<:Pair}; default=missing) = Select(options, default)
+	
+	Select(options::Base.Generator; default=missing) = Select([options...]; default)
 	
 	function Base.show(io::IO, m::MIME"text/html", select::Select)
 


### PR DESCRIPTION
This PR adds a method for select for the first argument of type Generator.
An example is added.

The added method only sometimes played nice when default values were provided. In my testing, I was unable to figure out the reason.
More testing should be done before this is merged to resolve the buggy behaviour when providing default values.

I am not sure how extensive testing is for this package, but testing should be added as

Thank you for opening a Pull Request at PlutoUI.jl!

# Before contributing code
Note that your code will be _Unlicensed_ when added to PlutoUI.jl, not _MIT_ licensed like contributions to Pluto.jl. Take a look at our license: https://github.com/fonsp/PlutoUI.jl/blob/main/LICENSE

