### PR TITLE
Fix CounterButton initial value

### DIFF
--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -376,7 +376,7 @@ begin
 		</script></span>"""))
 	end
 	
-	Base.get(button::CounterButton) = button.label
+	Base.get(button::CounterButton) = 0
 	Bonds.initial_value(b::CounterButton) = 0
 	Bonds.possible_values(b::CounterButton) = Bonds.InfinitePossibilities()
 	function Bonds.validate_value(b::CounterButton, val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ struct Uhm end
     @test repr(m, WithIOContext(u, prop = 1)) == "1"
 end
 
-default(x) = AbstractPlutoDingetjes.Bonds.initial_value(x)
+default(x) = Core.applicable(Base.get, x) ? Base.get(x) : AbstractPlutoDingetjes.Bonds.initial_value(x)
 transform(el, x) = AbstractPlutoDingetjes.Bonds.transform_value(el, x)
 
 @testset "Public API" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,14 @@ struct Uhm end
     @test repr(m, WithIOContext(u, prop = 1)) == "1"
 end
 
-default(x) = Core.applicable(Base.get, x) ? Base.get(x) : AbstractPlutoDingetjes.Bonds.initial_value(x)
+function default(x)
+    new = AbstractPlutoDingetjes.Bonds.initial_value(x)
+    if Core.applicable(Base.get, x)
+        # if the default value is defined with both the new and old API, make sure that both APIs return the same value.
+        @assert Base.get(x) == new
+    end
+    new
+end
 transform(el, x) = AbstractPlutoDingetjes.Bonds.transform_value(el, x)
 
 @testset "Public API" begin


### PR DESCRIPTION
Fixes a double update when a cell defining `CounterButton` refreshes.
I also changed the tests to catch this kind of problem, but I'm not sure if that's the right fix. Pluto ignores `initial_value` if there is a `Base.get`, but the docs for `initial_value` seem to say it shouldn't. So maybe this should be fixed in Pluto instead?