### PR TITLE
🍭 ToC: follow scroll location & styling updates

### DIFF
--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -152,8 +152,8 @@ const render = (elements) => {
 
 const tocNode = html`<nav class="plutoui-toc">
 	<header>
-     <span class="toc-toggle open-toc">📖</span>
-     <span class="toc-toggle closed-toc">📕</span>
+	 <span class="toc-toggle open-toc">📖</span>
+	 <span class="toc-toggle closed-toc">📕</span>
 	 \${title_text}
 	</header>
 	<section></section>
@@ -239,7 +239,7 @@ const toc_css = @htl """
 
 .plutoui-toc {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
-        "Segoe UI Emoji", "Segoe UI Symbol", system-ui, sans-serif;
+		"Segoe UI Emoji", "Segoe UI Symbol", system-ui, sans-serif;
 	--main-bg-color: #fafafa;
 	--pluto-output-color: hsl(0, 0%, 36%);
 	--pluto-output-h-color: hsl(0, 0%, 21%);
@@ -257,15 +257,15 @@ const toc_css = @htl """
 
 .plutoui-toc.aside {
 	color: var(--pluto-output-color);
-	position:fixed;
+	position: fixed;
 	right: 1rem;
 	top: 5rem;
 	width: min(80vw, 300px);
-	padding: 10px;
+	padding: 0.5em;
+	padding-top: 0em;
 	/* border: 3px solid rgba(0, 0, 0, 0.15); */
 	border-radius: 10px;
 	/* box-shadow: 0 0 11px 0px #00000010; */
-	/* That is, viewport minus top minus Live Docs */
 	max-height: calc(100vh - 5rem - 90px);
 	overflow: auto;
 	z-index: 40;
@@ -293,7 +293,7 @@ const toc_css = @htl """
 
 @media (prefers-reduced-motion) {
   .plutoui-toc.aside {
-    transition-duration: 0s;
+	transition-duration: 0s;
   }
 }
 
@@ -301,19 +301,22 @@ const toc_css = @htl """
 	cursor: pointer;
 	padding: 1em;
 	margin: -1em;
-    margin-right: -0.7em;
+	margin-right: -0.7em;
 }
 
 .plutoui-toc header {
 	display: block;
 	font-size: 1.5em;
-	margin-top: -0.1em;
+	/* margin-top: -0.1em; */
 	margin-bottom: 0.4em;
-	padding-bottom: 0.4em;
+	padding: 0.4em 0;
 	margin-left: 0;
 	margin-right: 0;
 	font-weight: bold;
-	border-bottom: 2px solid rgba(0, 0, 0, 0.15);
+	/* border-bottom: 2px solid rgba(0, 0, 0, 0.15); */
+	position: sticky;
+	top: 0px;
+	background: var(--main-bg-color);
 }
 
 .plutoui-toc section .toc-row {

--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -155,7 +155,8 @@ const render = (elements) => {
 		intersection_observer_2.observe(title_el)
 		header_to_index_entry_map.set(title_el, row)
 
-	last_level = className
+	if(className.startsWith("H"))
+		last_level = className
 		
 	return row
 })}`
@@ -528,6 +529,9 @@ lkjasfdlk jasdflkj asdf
 """
 fff(x) = x
 
+# ╔═╡ 27adc83b-c052-40fb-8a8d-7d6fcb7c8e30
+fff2 = 123
+
 # ╔═╡ b3e73e1a-f8b3-4973-a052-69c8f12ebbf1
 md"""
 ## Composition of software at a higher level
@@ -601,4 +605,5 @@ $p
 # ╠═731a4662-c329-42a2-ae71-7954140bb290
 # ╠═3ab2da5f-943e-42e8-8e46-4a7031ba4227
 # ╠═7b27a858-9d3a-4324-a56c-98e6f31d5929
+# ╠═27adc83b-c052-40fb-8a8d-7d6fcb7c8e30
 # ╠═b3e73e1a-f8b3-4973-a052-69c8f12ebbf1

--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -59,8 +59,8 @@ const include_definitions = $(toc.include_definitions)
 
 const tocNode = html`<nav class="plutoui-toc">
 	<header>
-	 <span class="toc-toggle open-toc">📖</span>
-	 <span class="toc-toggle closed-toc">📕</span>
+	 <span class="toc-toggle open-toc"></span>
+	 <span class="toc-toggle closed-toc"></span>
 	 \${title_text}
 	</header>
 	<section></section>
@@ -282,6 +282,7 @@ const toc_css = @htl """
 	--pluto-output-color: hsl(0, 0%, 36%);
 	--pluto-output-h-color: hsl(0, 0%, 21%);
 	--sidebar-li-active-bg: rgb(235, 235, 235);
+	--icon-filter: unset;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -290,6 +291,7 @@ const toc_css = @htl """
 		--pluto-output-color: hsl(0, 0%, 90%);
 		--pluto-output-h-color: hsl(0, 0%, 97%);
 		--sidebar-li-active-bg: rgb(82, 82, 82);
+		--icon-filter: invert(1);
 	}
 }
 
@@ -299,7 +301,7 @@ const toc_css = @htl """
 	right: 1rem;
 	top: 5rem;
 	width: min(80vw, 300px);
-	padding: 0.5em;
+	padding: 0.5rem;
 	padding-top: 0em;
 	/* border: 3px solid rgba(0, 0, 0, 0.15); */
 	border-radius: 10px;
@@ -337,17 +339,46 @@ const toc_css = @htl """
 
 .toc-toggle {
 	cursor: pointer;
-	padding: 1em;
-	margin: -1em;
-	margin-right: -0.7em;
+    padding: 1em;
+    margin: -1em;
+    margin-right: -0.7em;
+    line-height: 1em;
+    display: flex;
 }
 
+.toc-toggle::before {
+    content: "";
+    display: inline-block;
+    height: 1em;
+    width: 1em;
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/list-outline.svg");
+	/* generated using https://dopiaza.org/tools/datauri/index.php */
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiI+PHRpdGxlPmlvbmljb25zLXY1LW88L3RpdGxlPjxsaW5lIHgxPSIxNjAiIHkxPSIxNDQiIHgyPSI0NDgiIHkyPSIxNDQiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiMwMDA7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS13aWR0aDozMnB4Ii8+PGxpbmUgeDE9IjE2MCIgeTE9IjI1NiIgeDI9IjQ0OCIgeTI9IjI1NiIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6IzAwMDtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLXdpZHRoOjMycHgiLz48bGluZSB4MT0iMTYwIiB5MT0iMzY4IiB4Mj0iNDQ4IiB5Mj0iMzY4IiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojMDAwO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MzJweCIvPjxjaXJjbGUgY3g9IjgwIiBjeT0iMTQ0IiByPSIxNiIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6IzAwMDtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLXdpZHRoOjMycHgiLz48Y2lyY2xlIGN4PSI4MCIgY3k9IjI1NiIgcj0iMTYiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiMwMDA7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS13aWR0aDozMnB4Ii8+PGNpcmNsZSBjeD0iODAiIGN5PSIzNjgiIHI9IjE2IiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojMDAwO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MzJweCIvPjwvc3ZnPg==");
+    background-size: 1em;
+	filter: var(--icon-filter);
+}
+
+.aside .toc-toggle.open-toc:hover::before {
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/arrow-forward-outline.svg");
+	/* generated using https://dopiaza.org/tools/datauri/index.php */
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiI+PHRpdGxlPmlvbmljb25zLXY1LWE8L3RpdGxlPjxwb2x5bGluZSBwb2ludHM9IjI2OCAxMTIgNDEyIDI1NiAyNjggNDAwIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojMDAwO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NDhweCIvPjxsaW5lIHgxPSIzOTIiIHkxPSIyNTYiIHgyPSIxMDAiIHkyPSIyNTYiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiMwMDA7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS13aWR0aDo0OHB4Ii8+PC9zdmc+");
+}
+.aside .toc-toggle.closed-toc:hover::before {
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/arrow-back-outline.svg");
+	/* generated using https://dopiaza.org/tools/datauri/index.php */
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiI+PHRpdGxlPmlvbmljb25zLXY1LWE8L3RpdGxlPjxwb2x5bGluZSBwb2ludHM9IjI0NCA0MDAgMTAwIDI1NiAyNDQgMTEyIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojMDAwO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NDhweCIvPjxsaW5lIHgxPSIxMjAiIHkxPSIyNTYiIHgyPSI0MTIiIHkyPSIyNTYiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiMwMDA7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS13aWR0aDo0OHB4Ii8+PC9zdmc+");
+}
+
+
+
 .plutoui-toc header {
-	display: block;
+	display: flex;
+	align-items: center;
+	gap: .3em;
 	font-size: 1.5em;
 	/* margin-top: -0.1em; */
 	margin-bottom: 0.4em;
-	padding: 0.4em 0;
+	padding: 0.5rem;
 	margin-left: 0;
 	margin-right: 0;
 	font-weight: bold;
@@ -355,6 +386,11 @@ const toc_css = @htl """
 	position: sticky;
 	top: 0px;
 	background: var(--main-bg-color);
+	z-index: 41;
+}
+.plutoui-toc.aside header {
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .plutoui-toc section .toc-row {

--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -141,11 +141,13 @@ let intersection_observer_1 = new IntersectionObserver(intersection_callback, {
 	root: null, // i.e. the viewport
   	threshold: 1,
 	rootMargin: "-15px", // slightly smaller than the viewport
+	delay: 100,
 })
 let intersection_observer_2 = new IntersectionObserver(intersection_callback, {
 	root: null, // i.e. the viewport
   	threshold: 1,
 	rootMargin: "15px", // slightly larger than the viewport
+	delay: 100,
 })
 
 const render = (elements) => {

--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -29,9 +29,6 @@ end
 # ╔═╡ 3061a5a6-feda-4538-8076-30c70c9b8766
 import AbstractPlutoDingetjes: AbstractPlutoDingetjes, Bonds
 
-# ╔═╡ 7c32fd56-6cc5-420b-945b-53446833a125
-# TableOfContents(; aside = false)
-
 # ╔═╡ 6043d6c5-54e4-40c1-a8a5-aec3ad7e1aa0
 md"# asdfsf"
 
@@ -332,7 +329,7 @@ const toc_css = @htl """
 }
 
 
-.plutoui-toc section .toc-row.in-view {
+.plutoui-toc.aside section .toc-row.in-view {
 	background: var(--sidebar-li-active-bg);
 }
 
@@ -417,6 +414,9 @@ export TableOfContents
 
 # ╔═╡ fdf8750b-653e-4f23-8f8f-9e2ef4e24e75
 TableOfContents()
+
+# ╔═╡ 7c32fd56-6cc5-420b-945b-53446833a125
+TableOfContents(; aside = false)
 
 # ╔═╡ f11f9ead-bbe9-4fa5-b99c-408cc4a69a7e
 md"""

--- a/src/TableOfContents.jl
+++ b/src/TableOfContents.jl
@@ -118,7 +118,8 @@ const render = (elements) => {
 	currently_highlighted_set.clear()
 	intersection_observer_1.disconnect()
 	intersection_observer_2.disconnect()
-	
+
+		let last_level = `H1`
 	return html`\${elements.map(h => {
 	const parent_cell = getParentCell(h)
 
@@ -149,10 +150,12 @@ const render = (elements) => {
 		})
 	}
 
-	const row =  html`<div class="toc-row \${className}">\${a}</div>`
+	const row =  html`<div class="toc-row \${className} after-\${last_level}">\${a}</div>`
 		intersection_observer_1.observe(title_el)
 		intersection_observer_2.observe(title_el)
 		header_to_index_entry_map.set(title_el, row)
+
+	last_level = className
 		
 	return row
 })}`
@@ -365,24 +368,30 @@ const toc_css = @htl """
 	line-height: 1em;
 }
 
+.plutoui-toc.indent section a.H6,
+.plutoui-toc.indent section .after-H6 a  {
+	padding-left: 50px;
+}
+.plutoui-toc.indent section a.H5,
+.plutoui-toc.indent section .after-H5 a  {
+	padding-left: 40px;
+}
+.plutoui-toc.indent section a.H4,
+.plutoui-toc.indent section .after-H4 a  {
+	padding-left: 30px;
+}
+.plutoui-toc.indent section a.H3,
+.plutoui-toc.indent section .after-H3 a  {
+	padding-left: 20px;
+}
+.plutoui-toc.indent section a.H2,
+.plutoui-toc.indent section .after-H2 a {
+	padding-left: 10px;
+}
 .plutoui-toc.indent section a.H1 {
 	padding-left: 0px;
 }
-.plutoui-toc.indent section a.H2 {
-	padding-left: 10px;
-}
-.plutoui-toc.indent section a.H3 {
-	padding-left: 20px;
-}
-.plutoui-toc.indent section a.H4 {
-	padding-left: 30px;
-}
-.plutoui-toc.indent section a.H5 {
-	padding-left: 40px;
-}
-.plutoui-toc.indent section a.H6 {
-	padding-left: 50px;
-}
+
 .plutoui-toc.indent section a.pluto-docs-binding-el,
 .plutoui-toc.indent section a.ASSIGNEE
 	{
@@ -391,6 +400,7 @@ const toc_css = @htl """
 	/* background: black; */
 	font-weight: 700;
     font-style: italic;
+	color: var(--cm-var-color); /* this is stealing a variable from Pluto, but it's fine if that doesnt work */
 }
 .plutoui-toc.indent section a.pluto-docs-binding-el::before,
 .plutoui-toc.indent section a.ASSIGNEE::before


### PR DESCRIPTION
Updates:
- The header that is currently in view is highlighted (using `IntersectionObserver`). It even works when you click-to-scroll on an item!!
- A new option `include_definitions` to include Julia variable/function definitions in the ToC
- New flat style, matching https://plutojl-preview.netlify.app/docs/
- Use `system-ui` font stack instead of Alegreya Sans
- New icons instead of emoji to match Pluto's style
- Support for HTML inside headers: images, latex, highlighting, etc
- Hover on long title names to see the complete text
- Small margin above h1 headers, creating groups of all contained subheaders
- Fix invalidation bug that caused old ToC to sometimes continue rendering in the background
- Using HypertextLiteral

https://user-images.githubusercontent.com/6933510/191618623-86e4b349-12c5-4755-8315-95aa7b204d77.mov

