### PR TITLE
WebcamInput: RGB instead of RGBA

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using PlutoUI
 using Test
 import AbstractPlutoDingetjes
 using HypertextLiteral
-import ColorTypes: RGB, RGBA, N0f8, Colorant
+import ColorTypes: RGB, N0f8, Colorant
 import Logging
 using Dates
 
@@ -347,12 +347,12 @@ transform(el, x) = AbstractPlutoDingetjes.Bonds.transform_value(el, x)
     @test default(el) == 4:1//3:(17//3)
     
     el = WebcamInput(; help=false)
-    @test default(el) isa Matrix{RGBA{N0f8}}
+    @test default(el) isa Matrix{RGB{N0f8}}
     @test size(default(el)) == (1,1)
     
     el = WebcamInput(; help=false, avoid_allocs=true)
-    @test !(default(el) isa Matrix{RGBA{N0f8}})
-    @test default(el) isa AbstractMatrix{RGBA{N0f8}}
+    @test !(default(el) isa Matrix{RGB{N0f8}})
+    @test default(el) isa AbstractMatrix{RGB{N0f8}}
     @test size(default(el)) == (1,1)
 
 


### PR DESCRIPTION
Make WebcamInput output a `Matrix{RGB}` instead of `Matrix{RGBA}`, because:
- I found that this is easier to work with, more common in the Julia ecosystem (e.g. DitherPunk.jl supports `RGB` images, but not `RGBA`. PlutoUI.ColorPicker gives a `RGB`) and easier to understand
- It saves 25% of data being sent over the wire

This is technically breaking, but shhhhhhhh 🤫 thats a little secret. I did not really announce WebcamInput yet, and it has only been out for a day. Many scripts that used the old code will still work, unless they accessed the `.a` attribute. I think the advantages outweigh the worries about breaking something, so I am going for it.
