### PR TITLE
Fix uneven trailing whitespace in strings

### DIFF
--- a/src/Combine.jl
+++ b/src/Combine.jl
@@ -169,7 +169,7 @@ begin
 
 
 		let set_input_value = $(set_input_value_compat)
-	
+
 		Object.defineProperty(div, 'value', {
 			get: () => values,
 			set: (newvals) => {
@@ -183,7 +183,7 @@ begin
 		},
 			configurable: true,
 		});
-	
+
 		</script></span>""")
 		Base.show(io, m, output)
 	end

--- a/src/Confirm.jl
+++ b/src/Confirm.jl
@@ -176,7 +176,7 @@ begin
 			div.dispatchEvent(new CustomEvent("input", {}))
 		})
 
-	
+
 		Object.defineProperty(div, 'value', {
 			get: () => public_value,
 			set: (newval) => {
@@ -187,7 +187,7 @@ begin
 			},
 			configurable: true,
 		});
-	
+
 		</script></span>""")
 		Base.show(io, m, output)
 	end


### PR DESCRIPTION
Found as part of https://github.com/JuliaLang/julia/pull/46372 - the reference parser treats lines of uneven whitespace in a weird inconsistent way so there's some differences in whitespace in the final deindented string. This change removes those differences.