### PR TITLE
Add update_on_release option to Slider

### DIFF
--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -192,7 +192,8 @@ begin
 			const span_el = input_el.previousElementSibling
 			const show_value = $(slider.show_value)
 			const update_on_release = $(slider.update_on_release)
-			const updatevalue = () => {
+			const updatevalue = (e) => {
+				e.stopPropagation()
 				span_el.value = input_el.valueAsNumber
 				span_el.dispatchEvent(new CustomEvent("input"))
 			}
@@ -200,6 +201,7 @@ begin
 			if (update_on_release) {
 				input_el.addEventListener("mouseup", updatevalue)
 				input_el.addEventListener("touchend", updatevalue)
+				input_el.addEventListener("input", e => e.stopPropagation())
 			}
 			else {
 				input_el.addEventListener("input", updatevalue)

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -194,8 +194,11 @@ begin
 			const update_on_release = $(slider.update_on_release)
 			const updatevalue = (e) => {
 				e.stopPropagation()
-				span_el.value = input_el.valueAsNumber
-				span_el.dispatchEvent(new CustomEvent("input"))
+				const new_value = input_el.valueAsNumber
+				if (new_value !== span_el.value) {
+					span_el.value = new_value
+					span_el.dispatchEvent(new CustomEvent("input"))
+				}
 			}
 
 			if (update_on_release) {


### PR DESCRIPTION
Add `update_on_release` option to `Slider`. (Implement #267)

If this option is set to `true`, slider value changes will not take effect until the mouse button is released.
(The `confirm()` function is available for the similar purpose, but I thought it would be nice to have this option as well, since it is handy.)

![](https://github.com/JuliaPluto/PlutoUI.jl/assets/3076585/0991077f-374e-4034-b050-e6705a1c8779)

I have checked this to work in the following environment:

* Chrome 116 on PC (Xubuntu Linux 22.04)
* Firefox 117 on PC (Xubuntu Linux 22.04)
* Chrome 116 on iPad (iPadOS 16.6)
* Safari on iPad (iPadOS 16.6)
* Chrome 116 on Android (Android 13)

In order to support touch input, both "mouseup" and "touchend" events are watched by `addEventListener()` in the javascript code.
(The "mouseup" and "touchend" events did not seem to occur at the same time.)