### PR TITLE
WithIOContext: properties of the original IO should not be hidden

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,7 +18,7 @@ jobs:
         # continue-on-error: true
         strategy:
             matrix:
-                julia-version: ['1', '1.6']
+                julia-version: ['1.6', '1.7', '1']
                 os: [ubuntu-latest]
 
         steps:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,7 +18,7 @@ jobs:
         # continue-on-error: true
         strategy:
             matrix:
-                julia-version: ['1.4', '1.7']
+                julia-version: ['1', '1.6']
                 os: [ubuntu-latest]
 
         steps:

--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ JSON = "^0.21.1"
 MIMEs = "0.1"
 Reexport = "^1"
 URIs = "1"
-julia = "1.4"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DisplayTricks.jl
+++ b/src/DisplayTricks.jl
@@ -128,12 +128,19 @@ end
 
 Base.:(==)(w1::WithIOContext, w2::WithIOContext) = w1.x == w2.x && w1.context == w2.context
 
+# weird... 
+# - `IOContext(io, :a => :b)` will have all the properties from `io`, with `:a => :b` added, wheras
+# - `IOContext(io, second_io)` will only have the properties from `second_io`, with properties from `io` ignored.
+# 
+# This function will create an IOContext with all the properties from both `a` and `b`, with properties from `b` taking precedence.
+_layer_iocontext(a::IO, b::IOContext) = IOContext(a, (key => get(b, key, nothing) for key in keys(b))...)
+
 function Base.show(io::IO, m::MIME, w::WithIOContext)
-	Base.show(IOContext(io, w.context), m, w.x)
+	Base.show(_layer_iocontext(io, w.context), m, w.x)
 end
 # we need to add a more specific method for text/plain because Julia base has a fallback method here
 function Base.show(io::IO, m::MIME"text/plain", w::WithIOContext)
-	Base.show(IOContext(io, w.context), m, w.x)
+	Base.show(_layer_iocontext(io, w.context), m, w.x)
 end
 
 Base.showable(m::MIME, w::WithIOContext) = Base.showable(m, w.x)

--- a/src/DisplayTricks.jl
+++ b/src/DisplayTricks.jl
@@ -109,6 +109,9 @@ export WithIOContext
 
 A wrapper around `x` with extra IOContext properties set, just for the display of `x`.
 
+!!! compat "PlutoUI 0.7.52"
+    Before PlutoUI 0.7.52, `x` would be displayed using only the properties from `properties`, ignoring the properties from the IOContext used for the render. This has been fixed.
+
 # Examples
 
 ```julia

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,29 @@ struct Uhm end
 
     @test repr(MIME"text/plain"(), WithIOContext(1.345234523452, compact = true)) == "1.34523"
     @test repr(MIME"text/plain"(), WithIOContext(1.345234523452, compact = false)) == "1.345234523452"
+    
+    
+    # IO Contexts should layer:
+    
+    M = rand(20,20)
+    
+    w1 = PlutoUI.WithIOContext(M, :displaysize=>(10,20), :limit =>true)
+    
+    w2 = PlutoUI.WithIOContext(
+        PlutoUI.WithIOContext(M, :displaysize=>(10,20)),
+    :limit =>true)
+
+    @test repr(MIME"text/plain"(), w1) == 
+        repr(MIME"text/plain"(), w2)
+        
+        
+        
+        
+    @test repr(MIME"text/plain"(), w1) == repr(MIME"text/plain"(), M; context=IOContext(devnull, :displaysize=>(10,20), :limit=>true))
+    
+
+    @test repr(MIME"text/plain"(), w1) == 
+    repr(MIME"text/plain"(), PlutoUI.WithIOContext(M); context=IOContext(devnull, :displaysize=>(10,20), :limit=>true))
 
 
     m = MIME"hello"()


### PR DESCRIPTION
WIP