### PR TITLE
remove `@with_terminal` export

### DIFF
--- a/src/TerminalNotebook.jl
+++ b/src/TerminalNotebook.jl
@@ -187,7 +187,7 @@ function with_terminal(f, args...; color=true, show_value=true)
 end
 
 # ╔═╡ fe8c0c2f-8555-44f0-ae30-628ad4860157
-export with_terminal, @with_terminal
+export with_terminal
 
 # ╔═╡ 376b7763-dd17-4147-a246-a530ace698ec
 # ╠═╡ skip_as_script = true


### PR DESCRIPTION
This will remove the macro export from the TerminalNotebook as it's not defined anymore.

As it is now, you get an error with Aqua tests if you re-export PlutoUI (as it errors if you are exporting non-existing names)


