### PR TITLE
Download button: support multimedia

### DIFF
--- a/src/Resource.jl
+++ b/src/Resource.jl
@@ -140,12 +140,16 @@ DownloadButton(data) = DownloadButton(data, "result")
 
 function Base.show(io::IO, m::MIME"text/html", db::DownloadButton)
     mime = mime_fromfilename(db.filename)
-    data = to_data(db.data, mime)
+    data = if db.data isa String || db.data isa AbstractVector{UInt8} || isnothing(mime)
+        db.data
+    else
+        repr(mime, db.data)
+    end
 
     write(io, "<a href=\"data:")
 	write(io, string(!isnothing(mime) ? mime : ""))
 	write(io, ";base64,")
-	write(io, data)
+	write(io, Base64.base64encode(data))
 	write(io, "\" download=\"")
 	write(io, Markdown.htmlesc(db.filename))
 	write(io, "\" style=\"text-decoration: none; font-weight: normal; font-size: .75em; font-family: sans-serif;\"><button>Download...</button> ")
@@ -153,7 +157,7 @@ function Base.show(io::IO, m::MIME"text/html", db::DownloadButton)
 	write(io, "</a>")
 end
 
-function to_data(object::Any, mime::Union{MIME, Nothing})::String
+function downloadbutton_data(object::Any, mime::Union{MIME, Nothing})::String
     data = if object isa String || object isa AbstractVector{UInt8} || isnothing(mime)
         object
     else

--- a/src/Resource.jl
+++ b/src/Resource.jl
@@ -138,12 +138,14 @@ struct DownloadButton
 end
 DownloadButton(data) = DownloadButton(data, "result")
 
-
 function Base.show(io::IO, m::MIME"text/html", db::DownloadButton)
-	write(io, "<a href=\"data:")
-	write(io, string(mime_fromfilename(db.filename, default="")))
+    mime = mime_fromfilename(db.filename)
+    data = to_data(db.data, mime)
+
+    write(io, "<a href=\"data:")
+	write(io, string(!isnothing(mime) ? mime : ""))
 	write(io, ";base64,")
-	write(io, Base64.base64encode(db.data))
+	write(io, data)
 	write(io, "\" download=\"")
 	write(io, Markdown.htmlesc(db.filename))
 	write(io, "\" style=\"text-decoration: none; font-weight: normal; font-size: .75em; font-family: sans-serif;\"><button>Download...</button> ")
@@ -151,12 +153,22 @@ function Base.show(io::IO, m::MIME"text/html", db::DownloadButton)
 	write(io, "</a>")
 end
 
+function to_data(object::Any, mime::Union{MIME, Nothing})::String
+    data = if object isa String || object isa AbstractVector{UInt8} || isnothing(mime)
+        object
+    else
+        repr(mime, object)
+    end
+    Base64.base64encode(data)
+end
+
+
 ###
 # MIMES
 ###
 
 "Attempt to find the MIME pair corresponding to the extension of a filename. Defaults to `text/plain`."
-function mime_fromfilename(filename; default=nothing, filename_maxlength=2000)
+function mime_fromfilename(filename; default::T=nothing, filename_maxlength=2000)::Union{MIME, T} where T
 	if length(filename) > filename_maxlength
 		default
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,6 +133,17 @@ end
         
 end
 
+@testset "DownloadButton" begin
+    data = "test"
+    db1 = DownloadButton(data, "test.txt")
+    db2 = DownloadButton(html"<b>test</b>", "test.html")
+
+    hr(x) = repr(MIME"text/html"(), x)
+
+    hr(db1)
+    hr(db2)
+end
+
 function default(x)
     new = AbstractPlutoDingetjes.Bonds.initial_value(x)
     if Core.applicable(Base.get, x)


### PR DESCRIPTION
Makes it easier to download multimedia content without converting it to a binary array yourself.

For example, something like this:

```julia
using Images
img = load(download("https://whatever"))
DownloadButton(img, "image.png")
```

Also adds a simple unit test for the download button.