### PR TITLE
Add `details`

### DIFF
--- a/src/Details.jl
+++ b/src/Details.jl
@@ -59,6 +59,13 @@ pluto-output details summary {
 	margin: -0.5em -0.5em 0;
 	padding: 0.5em;
 	font-family: var(--system-ui-font-stack);
+	border-radius: 3px;
+	transition: color .25s ease-in-out, background-color .25s ease-in-out;
+}
+
+pluto-output details summary:hover {
+	color: var(--blockquote-color);
+	background-color: var(--blockquote-bg);
 }
 
 pluto-output details[open] {
@@ -66,6 +73,7 @@ pluto-output details[open] {
 }
 
 pluto-output details[open] summary {
+	border-radius: 3px 3px 0 0;
 	border-bottom: 1px solid var(--rule-color);
 	margin-bottom: 0.5em;
 }

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -4,6 +4,16 @@
 using Markdown
 using InteractiveUtils
 
+# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
+macro bind(def, element)
+    quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
+        local el = $(esc(element))
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
+        el
+    end
+end
+
 # ╔═╡ 81f5b495-76c4-4c54-93ab-b49c5ecb810a
 # ╠═╡ skip_as_script = true
 #=╠═╡
@@ -17,6 +27,12 @@ end
 
 # ╔═╡ b7b18a54-afd7-4467-83ed-cc4f07c321fb
 using HypertextLiteral
+
+# ╔═╡ b3732e34-d331-4dd2-b4fb-11b2f397d7c1
+# ╠═╡ skip_as_script = true
+#=╠═╡
+const testslider = html"<input>"
+  ╠═╡ =#
 
 # ╔═╡ 13e81634-3b72-4b1d-a89b-36d184698d21
 const details_css = @htl("""
@@ -37,11 +53,12 @@ pluto-output details:last-child {
 	margin-block-end: 0;
 }
 
-pluto-output summary {
+pluto-output details summary {
 	cursor: pointer;
 	font-weight: bold;
 	margin: -0.5em -0.5em 0;
 	padding: 0.5em;
+	font-family: var(--system-ui-font-stack);
 }
 
 pluto-output details[open] {
@@ -52,17 +69,6 @@ pluto-output details[open] summary {
 	border-bottom: 1px solid var(--rule-color);
 	margin-bottom: 0.5em;
 }
-
-plutoui-detail {
-	display: block;
-	line-height: 1.45em;
-	word-spacing: .053em;
-	margin-block-end: var(--pluto-cell-spacing);
-}
-
-plutoui-detail:last-child {
-	margin-block-end: 0;
-}
 </style>
 """)
 
@@ -71,21 +77,18 @@ const Iterable = Union{AbstractVector, Tuple, Base.Generator}
 
 # ╔═╡ 46521e2b-ea06-491a-9842-13dff7dc8299
 begin
-	embed_detail(detail::AbstractString) = detail
-	embed_detail(detail) = if isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display)
-		Main.PlutoRunner.embed_display(detail)
-	else
-		@htl("$(detail)")
-	end
+	const embed_detail = isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display) ? Main.PlutoRunner.embed_display : identity
 	
 	function details(summary::AbstractString, contents::Iterable; open::Bool=false)
 		@htl("""
 		$(details_css)
 		<details $(open ? (open=true,) : nothing)>
 			<summary>$(summary)</summary>
-			<div class="summary-details">
+			<div class="details-content">
 				$(Iterators.map(contents) do detail
-					@htl("<plutoui-detail>$(embed_detail(detail))</plutoui-detail>")
+					detail isa AbstractString ? 
+						@htl("<p>$(detail)</p>") : 
+						embed_detail(detail)
 				end)
 			</div>
 		</details>
@@ -93,7 +96,7 @@ begin
 	end
 
 	# Convenience function for when you just provide a single detail
-	details(summary::AbstractString, contents; open::Bool=false) = details(summary, [contents], open=open)
+	details(summary::AbstractString, contents; open::Bool=false) = details(summary, (contents,); open)
 
 	"""
 	```julia
@@ -132,7 +135,7 @@ begin
 	```
 	
 	!!! warning "Beware @bind in collection declaration"
-		You may want to `@bind` several variables within the `contents` argument by declaring a collection of `@bind` expressions. Wrap each `@bind` expression in parenthesis or interpolate them in `md` strings like the example above to prevent macro expansion from modifying how your collection declaration is interpreted.
+		You may want to `@bind` several variables within the `contents` argument by declaring a collection of `@bind` expressions. **Wrap each `@bind` expression in parenthesis** or interpolate them in `md` strings like the example above to prevent macro expansion from modifying how your collection declaration is interpreted.
 	
 	```julia
 	# This example will cause an error
@@ -152,23 +155,26 @@ end
 # ╠═╡ skip_as_script = true
 #=╠═╡
 begin
-	my_details = details("I'm going to take over the world! Would you like to know more?", [
-		"I'm going to start small",
-		md"#### But don't mark me down just yet!",
-		md"""
-		Here are my steps for world domination! 🌍
-		- Perfect my **evil laugh** 🦹
-		- Create **_Laser (Pointer) of Doom_™** ⚡
-		- Train **ninja cats** 🥷🐈
-		- Build **volcanic lair** 🌋
-		""",
-		["Cat", "Laser (Pointer) ", "Volcano"],
-		Dict(
-			:cat => "Fluffy",
-			:laser => "Pointy",
-			:volcano => "Toasty",
-		),
-	])
+	my_details = details(
+		"I'm going to take over the world! Would you like to know more?", 
+		[
+			"I'm going to start small",
+			md"#### But don't mark me down just yet!",
+			md"""
+			Here are my steps for world domination! 🌍
+			- Perfect my **evil laugh** 🦹
+			- Create **_Laser (Pointer) of Doom_™** ⚡
+			- Train **ninja cats** 🥷🐈
+			- Build **volcanic lair** 🌋
+			""",
+			["Cat", "Laser (Pointer) ", "Volcano"],
+			Dict(
+				:cat => "Fluffy",
+				:laser => "Pointy",
+				:volcano => "Toasty",
+			),
+		]
+	)
 	
 	md"""
 	# Details
@@ -178,14 +184,63 @@ begin
 end
   ╠═╡ =#
 
+# ╔═╡ b8434c11-2bb5-47ba-8562-e1176cba0af7
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details("hello", "asdf")
+  ╠═╡ =#
+
+# ╔═╡ f833a0bf-f7f7-417d-8cd9-5f93a90aecf6
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details("hello", "asdf"; open=true)
+  ╠═╡ =#
+
+# ╔═╡ ef3ebb39-03ce-407b-9796-cae10d88f4a0
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details("hello", md"asdf"; open=true)
+  ╠═╡ =#
+
+# ╔═╡ b7349133-2590-415c-9a11-15c85e897a5c
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details(
+	"My summary",
+	[
+		"My first item",
+		(@bind my_var testslider),
+		md"How are you feeling? $(@bind feeling testslider)",
+	],
+	open=true,
+)
+  ╠═╡ =#
+
+# ╔═╡ a5663932-9a19-4d6d-9b20-d6fefac8cf9d
+#=╠═╡
+my_var
+  ╠═╡ =#
+
+# ╔═╡ cd2bcfa2-5759-40d6-9358-3e7e605c5bc2
+#=╠═╡
+feeling
+  ╠═╡ =#
+
 # ╔═╡ 5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 export details
 
 # ╔═╡ Cell order:
-# ╟─81f5b495-76c4-4c54-93ab-b49c5ecb810a
+# ╠═81f5b495-76c4-4c54-93ab-b49c5ecb810a
 # ╠═b7b18a54-afd7-4467-83ed-cc4f07c321fb
-# ╟─da0fb772-9a70-4616-a540-5770a8d48476
+# ╠═da0fb772-9a70-4616-a540-5770a8d48476
+# ╠═b8434c11-2bb5-47ba-8562-e1176cba0af7
+# ╠═f833a0bf-f7f7-417d-8cd9-5f93a90aecf6
+# ╠═ef3ebb39-03ce-407b-9796-cae10d88f4a0
+# ╠═b3732e34-d331-4dd2-b4fb-11b2f397d7c1
+# ╠═b7349133-2590-415c-9a11-15c85e897a5c
+# ╠═a5663932-9a19-4d6d-9b20-d6fefac8cf9d
+# ╠═cd2bcfa2-5759-40d6-9358-3e7e605c5bc2
 # ╠═5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
-# ╟─13e81634-3b72-4b1d-a89b-36d184698d21
+# ╠═13e81634-3b72-4b1d-a89b-36d184698d21
 # ╟─df840588-23bd-4b03-b5ab-ef273052d198
 # ╠═46521e2b-ea06-491a-9842-13dff7dc8299

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -98,7 +98,6 @@ begin
 	
 	function details(summary::AbstractString, contents::Iterable; open::Bool=false)
 		@htl("""
-		$(details_css)
 		<details $(open ? (open=true,) : nothing)>
 			<summary>$(summary)</summary>
 			<div class="details-content">
@@ -107,6 +106,7 @@ begin
 				end)
 			</div>
 		</details>
+		$(details_css)
 		""")
 	end
 

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -1,0 +1,191 @@
+### A Pluto.jl notebook ###
+# v0.19.38
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 81f5b495-76c4-4c54-93ab-b49c5ecb810a
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	import Pkg
+	Pkg.activate(Base.current_project(@__DIR__))
+	Pkg.instantiate()
+	md"**Project env active**"
+end
+  ╠═╡ =#
+
+# ╔═╡ b7b18a54-afd7-4467-83ed-cc4f07c321fb
+using HypertextLiteral
+
+# ╔═╡ 13e81634-3b72-4b1d-a89b-36d184698d21
+const details_css = @htl("""
+<style type="text/css">
+pluto-output details {
+	border: 1px solid var(--rule-color);
+	border-radius: 4px;
+	padding: 0.5em 0.5em 0;
+	margin-block-start: 0;
+	margin-block-end: var(--pluto-cell-spacing);
+}
+
+pluto-output details:first-child {
+	margin-block-start: 0;
+}
+
+pluto-output details:last-child {
+	margin-block-end: 0;
+}
+
+pluto-output summary {
+	cursor: pointer;
+	font-weight: bold;
+	margin: -0.5em -0.5em 0;
+	padding: 0.5em;
+}
+
+pluto-output details[open] {
+	padding: 0.5em;
+}
+
+pluto-output details[open] summary {
+	border-bottom: 1px solid var(--rule-color);
+	margin-bottom: 0.5em;
+}
+
+plutoui-detail {
+	display: block;
+	line-height: 1.45em;
+	word-spacing: .053em;
+	margin-block-end: var(--pluto-cell-spacing);
+}
+
+plutoui-detail:last-child {
+	margin-block-end: 0;
+}
+</style>
+""")
+
+# ╔═╡ df840588-23bd-4b03-b5ab-ef273052d198
+const Iterable = Union{AbstractVector, Tuple, Base.Generator}
+
+# ╔═╡ 46521e2b-ea06-491a-9842-13dff7dc8299
+begin
+	embed_detail(detail::AbstractString) = detail
+	embed_detail(detail) = if isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display)
+		Main.PlutoRunner.embed_display(detail)
+	else
+		@htl("$(detail)")
+	end
+	
+	function details(summary::AbstractString, contents::Iterable; open::Bool=false)
+		@htl("""
+		$(details_css)
+		<details $(open ? (open=true,) : nothing)>
+			<summary>$(summary)</summary>
+			<div class="summary-details">
+				$(Iterators.map(contents) do detail
+					@htl("<plutoui-detail>$(embed_detail(detail))</plutoui-detail>")
+				end)
+			</div>
+		</details>
+		""")
+	end
+
+	# Convenience function for when you just provide a single detail
+	details(summary::AbstractString, contents; open::Bool=false) = details(summary, [contents], open=open)
+
+	"""
+	```julia
+	details(summary::AbstractString, contents; open::Bool=false)
+	```
+	
+	Create a collapsable details disclosure element (`<details>`).
+	
+	Useful for initially hiding content that may be important yet overly verbose or exposing advanced variables that may not always need displayed.
+	
+	# Arguments
+	
+	- `summary::AbstractString`: the always visible summary of the details element.
+	- `contents::Any`: the item(s) to nest within the details element.
+	
+	# Keyword arguments
+	
+	- `open::Bool=false`: whether the details element is initially open.
+	
+	# Examples
+	
+	```julia
+	details("My summary", "Some contents")
+	```
+	
+	```julia
+	details(
+		"My summary",
+		[
+			"My first item",
+			(@bind my_var Slider(1:10)),
+			md"How are you feeling? \$(@bind feeling Slider(1:10))",
+		],
+		open=true,
+	)
+	```
+	
+	!!! warning "Beware @bind in collection declaration"
+		You may want to `@bind` several variables within the `contents` argument by declaring a collection of `@bind` expressions. Wrap each `@bind` expression in parenthesis or interpolate them in `md` strings like the example above to prevent macro expansion from modifying how your collection declaration is interpreted.
+	
+	```julia
+	# This example will cause an error
+	details(
+		"My summary",
+		[
+			"My first item",
+			@bind my_var Slider(1:10),
+		]
+	)
+	```
+	"""
+	details
+end
+
+# ╔═╡ da0fb772-9a70-4616-a540-5770a8d48476
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	my_details = details("I'm going to take over the world! Would you like to know more?", [
+		"I'm going to start small",
+		md"#### But don't mark me down just yet!",
+		md"""
+		Here are my steps for world domination! 🌍
+		- Perfect my **evil laugh** 🦹
+		- Create **_Laser (Pointer) of Doom_™** ⚡
+		- Train **ninja cats** 🥷🐈
+		- Build **volcanic lair** 🌋
+		""",
+		["Cat", "Laser (Pointer) ", "Volcano"],
+		Dict(
+			:cat => "Fluffy",
+			:laser => "Pointy",
+			:volcano => "Toasty",
+		),
+	])
+	
+	md"""
+	# Details
+	
+	$(my_details)
+	"""
+end
+  ╠═╡ =#
+
+# ╔═╡ 5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
+export details
+
+# ╔═╡ Cell order:
+# ╟─81f5b495-76c4-4c54-93ab-b49c5ecb810a
+# ╠═b7b18a54-afd7-4467-83ed-cc4f07c321fb
+# ╟─da0fb772-9a70-4616-a540-5770a8d48476
+# ╠═5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
+# ╟─13e81634-3b72-4b1d-a89b-36d184698d21
+# ╟─df840588-23bd-4b03-b5ab-ef273052d198
+# ╠═46521e2b-ea06-491a-9842-13dff7dc8299

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -77,6 +77,14 @@ pluto-output details[open] summary {
 	border-bottom: 1px solid var(--rule-color);
 	margin-bottom: 0.5em;
 }
+
+plutoui-detail {
+	display: block;
+	margin-block-end: var(--pluto-cell-spacing);
+}
+plutoui-detail:last-child {
+	margin-block-end: 0;
+}
 </style>
 """)
 
@@ -85,7 +93,8 @@ const Iterable = Union{AbstractVector, Tuple, Base.Generator}
 
 # ╔═╡ 46521e2b-ea06-491a-9842-13dff7dc8299
 begin
-	const embed_detail = isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display) ? Main.PlutoRunner.embed_display : identity
+	embed_detail(x) = isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display) ? Main.PlutoRunner.embed_display(x) : x
+	embed_detail(x::AbstractString) = x
 	
 	function details(summary::AbstractString, contents::Iterable; open::Bool=false)
 		@htl("""
@@ -94,9 +103,7 @@ begin
 			<summary>$(summary)</summary>
 			<div class="details-content">
 				$(Iterators.map(contents) do detail
-					detail isa AbstractString ? 
-						@htl("<p>$(detail)</p>") : 
-						embed_detail(detail)
+					@htl("<plutoui-detail>$(embed_detail(detail))</plutoui-detail>")
 				end)
 			</div>
 		</details>
@@ -167,6 +174,8 @@ begin
 		"I'm going to take over the world! Would you like to know more?", 
 		[
 			"I'm going to start small",
+			"I'm going to start small",
+			"I'm going to start small",
 			md"#### But don't mark me down just yet!",
 			md"""
 			Here are my steps for world domination! 🌍
@@ -175,13 +184,14 @@ begin
 			- Train **ninja cats** 🥷🐈
 			- Build **volcanic lair** 🌋
 			""",
+			@htl("<p>Fantastic!</p>"),
 			["Cat", "Laser (Pointer) ", "Volcano"],
 			Dict(
 				:cat => "Fluffy",
 				:laser => "Pointy",
 				:volcano => "Toasty",
 			),
-		]
+		]; open=true
 	)
 	
 	md"""

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -621,8 +621,8 @@ plutoui-detail:last-child {
 
 # ╔═╡ 0d6ce65d-dbd0-4016-a052-009911011108
 begin
-	local embed(detail::AbstractString) = detail
-	local embed(detail) = embed_display(detail)
+	embed_detail(detail::AbstractString) = detail
+	embed_detail(detail) = embed_display(detail)
 	
 	function details(summary::AbstractString, contents::Union{AbstractVector,Tuple,Base.Generator}; open::Bool=false)
 		@htl("""
@@ -631,7 +631,7 @@ begin
 			<summary>$(summary)</summary>
 			<div class="summary-details">
 				$(map(contents) do detail
-					@htl("<plutoui-detail>$(embed(detail))</plutoui-detail>")
+					@htl("<plutoui-detail>$(embed_detail(detail))</plutoui-detail>")
 				end)
 			</div>
 		</details>

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.38
+# v0.19.12
 
 using Markdown
 using InteractiveUtils
@@ -571,154 +571,6 @@ end
 aside(embed_display(p))
   ╠═╡ =#
 
-# ╔═╡ c11eafa2-ddce-418b-8a3a-6673392511d0
-const details_css = @htl("""
-<style type="text/css">
-pluto-output details {
-	border: 1px solid var(--rule-color);
-	border-radius: 4px;
-	padding: 0.5em 0.5em 0;
-	margin-block-start: 0;
-	margin-block-end: var(--pluto-cell-spacing);
-}
-
-pluto-output details:first-child {
-	margin-block-start: 0;
-}
-
-pluto-output details:last-child {
-	margin-block-end: 0;
-}
-
-pluto-output summary {
-	cursor: pointer;
-	font-weight: bold;
-	margin: -0.5em -0.5em 0;
-	padding: 0.5em;
-}
-
-pluto-output details[open] {
-	padding: 0.5em;
-}
-
-pluto-output details[open] summary {
-	border-bottom: 1px solid var(--rule-color);
-	margin-bottom: 0.5em;
-}
-
-plutoui-detail {
-	display: block;
-	line-height: 1.45em;
-	word-spacing: .053em;
-	margin-block-end: var(--pluto-cell-spacing);
-}
-
-plutoui-detail:last-child {
-	margin-block-end: 0;
-}
-</style>
-""")
-
-# ╔═╡ 0d6ce65d-dbd0-4016-a052-009911011108
-begin
-	embed_detail(detail::AbstractString) = detail
-	embed_detail(detail) = embed_display(detail)
-	
-	function details(summary::AbstractString, contents::Union{AbstractVector,Tuple,Base.Generator}; open::Bool=false)
-		@htl("""
-		$(details_css)
-		<details $(open ? (open=true,) : nothing)>
-			<summary>$(summary)</summary>
-			<div class="summary-details">
-				$(Iterators.map(contents) do detail
-					@htl("<plutoui-detail>$(embed_detail(detail))</plutoui-detail>")
-				end)
-			</div>
-		</details>
-		""")
-	end
-
-	# Convenience function for when you just provide a single detail
-	details(summary::AbstractString, contents; open::Bool=false) = details(summary, [contents], open=open)
-
-	"""
-	```julia
-	details(summary::AbstractString, contents; open::Bool=false)
-	```
-	
-	Create a collapsable details disclosure element.
-	
-	Useful for initially hiding content that may be important yet overly verbose or advanced variables that may not always need displayed.
-
-	# Examples
-
-	```julia
-	details("My summary", "Some contents")
-	```
-	
-	```julia
-	details(
-		"My summary",
-		[
-			"My first item",
-			(@bind my_var Slider(1:10)),
-			md"How are you feeling? \$(@bind feeling Slider(1:10))",
-		],
-		open=true,
-	)
-	```
-
-	!!! warning "Beware @bind in collection declaration"
-		You may want to `@bind` several variables with `contents` by inlining a collection of `@bind` expressions. Wrap each `@bind` expression in parenthesis or interpolate them in `md` strings like the example above to prevent macro expansion from modifying how your collection declaration is interpreted.
-
-	```julia
-	# This example will cause an error
-	details(
-		"My summary",
-		[
-			"My first item",
-			@bind my_var Slider(1:10),
-		]
-	)
-	```
-	"""
-	details
-end
-
-# ╔═╡ 9cd41081-68ac-4b46-bc78-8d4c028faed9
-#=╠═╡
-begin
-	my_details = details("I'm going to take over the world! Would you like to know more?", [
-		"I'm going to start small",
-		md"#### But don't mark me down just yet!",
-		md"""
-		Here are my steps for world domination! 🌍
-		- Perfect my **evil laugh** 🦹
-		- Create **_Laser (Pointer) of Doom_™** ⚡
-		- Train **ninja cats** 🥷🐈
-		- Build **volcanic lair** 🌋
-		""",
-		["Cat", "Laser (Pointer) ", "Volcano"],
-		Dict(
-			:cat => "Fluffy",
-			:laser => "Pointy",
-			:volcano => "Toasty",
-		),
-		"Maybe I'll need a guard dog too?",
-		p,
-	])
-	
-	md"""
-	# Details
-	
-	$(my_details)
-	"""
-end
-  ╠═╡ =#
-
-# ╔═╡ 716a13e2-d615-4032-86e9-a2085c95f252
-export details
-
 # ╔═╡ Cell order:
 # ╠═9113b5a3-d1a6-4594-bb84-33f9ae56c9e5
 # ╠═dd45b118-7a4d-45b3-8961-0c4fb337841b
@@ -777,13 +629,9 @@ export details
 # ╟─916f95ff-f568-48cc-91c3-ef2d2c9e397a
 # ╠═d24dfd97-5100-45f4-be12-ad30f98cc519
 # ╠═18cc9fbe-a37a-11eb-082b-e99673bd677d
-# ╟─9a166646-75c2-4711-9fad-665b01731759
+# ╠═9a166646-75c2-4711-9fad-665b01731759
 # ╠═d373edd9-5537-4f15-8c36-31aebc2569b5
 # ╟─50c3dce4-48c7-46b4-80a4-5af9cd83a0a8
-# ╠═87d374e1-e75f-468f-bc90-59d2013c361f
+# ╟─87d374e1-e75f-468f-bc90-59d2013c361f
 # ╠═773685a4-a6f7-4f59-98d5-83adcd176a8e
-# ╠═9d82ca2b-664d-461e-a93f-61c467bd983a
-# ╟─9cd41081-68ac-4b46-bc78-8d4c028faed9
-# ╠═716a13e2-d615-4032-86e9-a2085c95f252
-# ╟─c11eafa2-ddce-418b-8a3a-6673392511d0
-# ╠═0d6ce65d-dbd0-4016-a052-009911011108
+# ╟─9d82ca2b-664d-461e-a93f-61c467bd983a

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -571,61 +571,62 @@ end
 aside(embed_display(p))
   ╠═╡ =#
 
+# ╔═╡ c11eafa2-ddce-418b-8a3a-6673392511d0
+const details_css = @htl("""
+<style type="text/css">
+pluto-output details {
+	border: 1px solid var(--rule-color);
+	border-radius: 4px;
+	padding: 0.5em 0.5em 0;
+	margin-block-start: 0;
+	margin-block-end: var(--pluto-cell-spacing);
+}
+
+pluto-output details:first-child {
+	margin-block-start: 0;
+}
+
+pluto-output details:last-child {
+	margin-block-end: 0;
+}
+
+pluto-output summary {
+	cursor: pointer;
+	font-weight: bold;
+	margin: -0.5em -0.5em 0;
+	padding: 0.5em;
+}
+
+pluto-output details[open] {
+	padding: 0.5em;
+}
+
+pluto-output details[open] summary {
+	border-bottom: 1px solid var(--rule-color);
+	margin-bottom: 0.5em;
+}
+
+plutoui-detail {
+	display: block;
+	line-height: 1.45em;
+	word-spacing: .053em;
+	margin-block-end: var(--pluto-cell-spacing);
+}
+
+plutoui-detail:last-child {
+	margin-block-end: 0;
+}
+</style>
+""")
+
 # ╔═╡ 0d6ce65d-dbd0-4016-a052-009911011108
 begin
-	local style = @htl("""
-	<style type="text/css">
-	pluto-output details {
-		border: 1px solid var(--rule-color);
-		border-radius: 4px;
-		padding: 0.5em 0.5em 0;
-		margin-block-start: 0;
-		margin-block-end: var(--pluto-cell-spacing);
-	}
-	
-	pluto-output details:first-child {
-		margin-block-start: 0;
-	}
-	
-	pluto-output details:last-child {
-		margin-block-end: 0;
-	}
-	
-	pluto-output summary {
-		cursor: pointer;
-		font-weight: bold;
-		margin: -0.5em -0.5em 0;
-		padding: 0.5em;
-	}
-	
-	pluto-output details[open] {
-		padding: 0.5em;
-	}
-	
-	pluto-output details[open] summary {
-		border-bottom: 1px solid var(--rule-color);
-		margin-bottom: 0.5em;
-	}
-	
-	plutoui-detail {
-		display: block;
-		line-height: 1.45em;
-		word-spacing: .053em;
-		margin-block-end: var(--pluto-cell-spacing);
-	}
-	
-	plutoui-detail:last-child {
-		margin-block-end: 0;
-	}
-	</style>
-	""")
-	
 	local embed(detail::AbstractString) = detail
 	local embed(detail) = embed_display(detail)
 	
 	function details(summary::AbstractString, contents::Union{AbstractVector,Tuple,Base.Generator}; open::Bool=false)
 		@htl("""
-		$(style)
+		$(details_css)
 		<details $(open ? (open=true,) : nothing)>
 			<summary>$(summary)</summary>
 			<div class="summary-details">
@@ -777,4 +778,5 @@ export details
 # ╠═9d82ca2b-664d-461e-a93f-61c467bd983a
 # ╟─9cd41081-68ac-4b46-bc78-8d4c028faed9
 # ╠═716a13e2-d615-4032-86e9-a2085c95f252
-# ╠═0d6ce65d-dbd0-4016-a052-009911011108
+# ╟─c11eafa2-ddce-418b-8a3a-6673392511d0
+# ╟─0d6ce65d-dbd0-4016-a052-009911011108

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -657,11 +657,15 @@ begin
 	```
 	
 	```julia
-	details("My summary", [
-		"My first item",
-		(@bind my_var Slider(1:10)),
-		md"How are you feeling? \$(@bind feeling Slider(1:10))",
-	])
+	details(
+		"My summary",
+		[
+			"My first item",
+			(@bind my_var Slider(1:10)),
+			md"How are you feeling? \$(@bind feeling Slider(1:10))",
+		],
+		open=true,
+	)
 	```
 
 	!!! warning "Beware @bind in collection declaration"
@@ -669,10 +673,13 @@ begin
 
 	```julia
 	# This example will cause an error
-	details("My summary", [
-		"My first item",
-		@bind my_var Slider(1:10),
-	])
+	details(
+		"My summary",
+		[
+			"My first item",
+			@bind my_var Slider(1:10),
+		]
+	)
 	```
 	"""
 	details
@@ -779,4 +786,4 @@ export details
 # ╟─9cd41081-68ac-4b46-bc78-8d4c028faed9
 # ╠═716a13e2-d615-4032-86e9-a2085c95f252
 # ╟─c11eafa2-ddce-418b-8a3a-6673392511d0
-# ╟─0d6ce65d-dbd0-4016-a052-009911011108
+# ╠═0d6ce65d-dbd0-4016-a052-009911011108

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -630,7 +630,7 @@ begin
 		<details $(open ? (open=true,) : nothing)>
 			<summary>$(summary)</summary>
 			<div class="summary-details">
-				$(map(contents) do detail
+				$(Iterators.map(contents) do detail
 					@htl("<plutoui-detail>$(embed_detail(detail))</plutoui-detail>")
 				end)
 			</div>

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -623,9 +623,7 @@ begin
 	local embed(detail::AbstractString) = detail
 	local embed(detail) = embed_display(detail)
 	
-	local Iterable = Union{AbstractVector,Tuple,Base.Generator}
-	
-	function details(summary::AbstractString, contents::Iterable; open::Bool=false)
+	function details(summary::AbstractString, contents::Union{AbstractVector,Tuple,Base.Generator}; open::Bool=false)
 		@htl("""
 		$(style)
 		<details $(open ? (open=true,) : nothing)>
@@ -640,7 +638,7 @@ begin
 	end
 
 	# Convenience function for when you just provide a single detail
-	details(summary::AbstractString, contents; open::Bool=false) = details(summary, (contents,), open=open)
+	details(summary::AbstractString, contents; open::Bool=false) = details(summary, [contents], open=open)
 
 	"""
 	```julia

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -642,12 +642,12 @@ begin
 
 	"""
 	```julia
-	details(summary::AbstractString, contents; [open::Bool=false])
+	details(summary::AbstractString, contents; open::Bool=false)
 	```
 	
 	Create a collapsable details disclosure element.
 	
-	Useful for initially hiding content that may be important yet overly verbose or advanced variables that may not always be worthy of screen space.
+	Useful for initially hiding content that may be important yet overly verbose or advanced variables that may not always need displayed.
 
 	# Examples
 
@@ -659,17 +659,18 @@ begin
 	details("My summary", [
 		"My first item",
 		(@bind my_var Slider(1:10)),
-		md"How are you feeling? \$(@bind my_var Slider(1:10))",
+		md"How are you feeling? \$(@bind feeling Slider(1:10))",
 	])
 	```
 
 	!!! warning "Beware @bind in collection declaration"
-		You may want to `@bind` several variables within the details element by inlining a collection of `@bind` expressions, to do so you need to be careful of how macro expansion operates. Wrapping each `@bind` expression in parenthesis or interpolating them in markdown strings with `md` like the example above will prevent issues where the macro expansion modifies how your collection declaration is interpreted.
+		You may want to `@bind` several variables with `contents` by inlining a collection of `@bind` expressions. Wrap each `@bind` expression in parenthesis or interpolate them in `md` strings like the example above to prevent macro expansion from modifying how your collection declaration is interpreted.
 
 	```julia
+	# This example will cause an error
 	details("My summary", [
 		"My first item",
-		@bind my_var Slider(1:10),  # This will cause an error
+		@bind my_var Slider(1:10),
 	])
 	```
 	"""

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -646,6 +646,7 @@ begin
 	```julia
 	details(summary::AbstractString, contents; [open::Bool=false])
 	```
+	
 	Create a collapsable details disclosure element.
 	
 	Useful for initially hiding content that may be important yet overly verbose or advanced variables that may not always be worthy of screen space.
@@ -664,8 +665,15 @@ begin
 	])
 	```
 
-	!!! warning "Beware `@bind` in list"
-		You may want to `@bind` several variables within the details element by inlining a list of `@bind` expressions, but you have to be careful of how macro expansion operates. Wrapping each `@bind` expression in parenthesis or interpolating them in markdown strings with `md` like the example above will prevent issues where the macro expansion modifies how your inlined list is interpreted.
+	!!! warning "Beware @bind in collection declaration"
+		You may want to `@bind` several variables within the details element by inlining a collection of `@bind` expressions, to do so you need to be careful of how macro expansion operates. Wrapping each `@bind` expression in parenthesis or interpolating them in markdown strings with `md` like the example above will prevent issues where the macro expansion modifies how your collection declaration is interpreted.
+
+	```julia
+	details("My summary", [
+		"My first item",
+		@bind my_var Slider(1:10),  # This will cause an error
+	])
+	```
 	"""
 	details
 end

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.12
+# v0.19.38
 
 using Markdown
 using InteractiveUtils
@@ -571,6 +571,139 @@ end
 aside(embed_display(p))
   ╠═╡ =#
 
+# ╔═╡ 0d6ce65d-dbd0-4016-a052-009911011108
+begin
+	local style = @htl("""
+	<style type="text/css">
+	pluto-output details {
+		border: 1px solid var(--rule-color);
+		border-radius: 4px;
+		padding: 0.5em 0.5em 0;
+		margin-block-start: 0;
+		margin-block-end: var(--pluto-cell-spacing);
+	}
+	
+	pluto-output details:first-child {
+		margin-block-start: 0;
+	}
+	
+	pluto-output details:last-child {
+		margin-block-end: 0;
+	}
+	
+	pluto-output summary {
+		cursor: pointer;
+		font-weight: bold;
+		margin: -0.5em -0.5em 0;
+		padding: 0.5em;
+	}
+	
+	pluto-output details[open] {
+		padding: 0.5em;
+	}
+	
+	pluto-output details[open] summary {
+		border-bottom: 1px solid var(--rule-color);
+		margin-bottom: 0.5em;
+	}
+	
+	plutoui-detail {
+		display: block;
+		line-height: 1.45em;
+		word-spacing: .053em;
+		margin-block-end: var(--pluto-cell-spacing);
+	}
+	
+	plutoui-detail:last-child {
+		margin-block-end: 0;
+	}
+	</style>
+	""")
+	
+	local embed(detail::AbstractString) = detail
+	local embed(detail) = embed_display(detail)
+	
+	local Iterable = Union{AbstractVector,Tuple,Base.Generator}
+	
+	function details(summary::AbstractString, contents::Iterable; open::Bool=false)
+		@htl("""
+		$(style)
+		<details $(open ? (open=true,) : nothing)>
+			<summary>$(summary)</summary>
+			<div class="summary-details">
+				$(map(contents) do detail
+					@htl("<plutoui-detail>$(embed(detail))</plutoui-detail>")
+				end)
+			</div>
+		</details>
+		""")
+	end
+
+	# Convenience function for when you just provide a single detail
+	details(summary::AbstractString, contents; open::Bool=false) = details(summary, (contents,), open=open)
+
+	"""
+	```julia
+	details(summary::AbstractString, contents; [open::Bool=false])
+	```
+	Create a collapsable details disclosure element.
+	
+	Useful for initially hiding content that may be important yet overly verbose or advanced variables that may not always be worthy of screen space.
+
+	# Examples
+
+	```julia
+	details("My summary", "Some contents")
+	```
+	
+	```julia
+	details("My summary", [
+		"My first item",
+		(@bind my_var Slider(1:10)),
+		md"How are you feeling? \$(@bind my_var Slider(1:10))",
+	])
+	```
+
+	!!! warning "Beware `@bind` in list"
+		You may want to `@bind` several variables within the details element by inlining a list of `@bind` expressions, but you have to be careful of how macro expansion operates. Wrapping each `@bind` expression in parenthesis or interpolating them in markdown strings with `md` like the example above will prevent issues where the macro expansion modifies how your inlined list is interpreted.
+	"""
+	details
+end
+
+# ╔═╡ 9cd41081-68ac-4b46-bc78-8d4c028faed9
+#=╠═╡
+begin
+	my_details = details("I'm going to take over the world! Would you like to know more?", [
+		"I'm going to start small",
+		md"#### But don't mark me down just yet!",
+		md"""
+		Here are my steps for world domination! 🌍
+		- Perfect my **evil laugh** 🦹
+		- Create **_Laser (Pointer) of Doom_™** ⚡
+		- Train **ninja cats** 🥷🐈
+		- Build **volcanic lair** 🌋
+		""",
+		["Cat", "Laser (Pointer) ", "Volcano"],
+		Dict(
+			:cat => "Fluffy",
+			:laser => "Pointy",
+			:volcano => "Toasty",
+		),
+		"Maybe I'll need a guard dog too?",
+		p,
+	])
+	
+	md"""
+	# Details
+	
+	$(my_details)
+	"""
+end
+  ╠═╡ =#
+
+# ╔═╡ 716a13e2-d615-4032-86e9-a2085c95f252
+export details
+
 # ╔═╡ Cell order:
 # ╠═9113b5a3-d1a6-4594-bb84-33f9ae56c9e5
 # ╠═dd45b118-7a4d-45b3-8961-0c4fb337841b
@@ -629,9 +762,12 @@ aside(embed_display(p))
 # ╟─916f95ff-f568-48cc-91c3-ef2d2c9e397a
 # ╠═d24dfd97-5100-45f4-be12-ad30f98cc519
 # ╠═18cc9fbe-a37a-11eb-082b-e99673bd677d
-# ╠═9a166646-75c2-4711-9fad-665b01731759
+# ╟─9a166646-75c2-4711-9fad-665b01731759
 # ╠═d373edd9-5537-4f15-8c36-31aebc2569b5
 # ╟─50c3dce4-48c7-46b4-80a4-5af9cd83a0a8
-# ╟─87d374e1-e75f-468f-bc90-59d2013c361f
+# ╠═87d374e1-e75f-468f-bc90-59d2013c361f
 # ╠═773685a4-a6f7-4f59-98d5-83adcd176a8e
-# ╟─9d82ca2b-664d-461e-a93f-61c467bd983a
+# ╠═9d82ca2b-664d-461e-a93f-61c467bd983a
+# ╟─9cd41081-68ac-4b46-bc78-8d4c028faed9
+# ╠═716a13e2-d615-4032-86e9-a2085c95f252
+# ╠═0d6ce65d-dbd0-4016-a052-009911011108

--- a/src/PlutoUI.jl
+++ b/src/PlutoUI.jl
@@ -44,6 +44,10 @@ end # 0.06 second
 # not exporting to avoid clash with DataFrames.combine
 const combine = CombineNotebook.combine
 
+@reexport module DetailsNotebook
+    include("./Details.jl")
+end # ? second
+
 # this is a submodule
 using HypertextLiteral
 using Hyperscript

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -292,7 +292,7 @@ transform(el, x) = AbstractPlutoDingetjes.Bonds.transform_value(el, x)
 
     @test hrd(details("a", "b"))
     @test hrd(details("a", ("b","c"); open=true))
-    @test hrd(details("a", [md"b", Slider(1:10)]; open=true))
+    @test hrd(details("a", [htl"b", Slider(1:10)]; open=true))
 
     el = Slider(0.0:π:20)
     @test default(el) == 0
@@ -503,4 +503,3 @@ transform(el, x) = AbstractPlutoDingetjes.Bonds.transform_value(el, x)
     el = Scrubbable(A)
     @test default(el) == A
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,10 +288,11 @@ transform(el, x) = AbstractPlutoDingetjes.Bonds.transform_value(el, x)
     el = Radio(["sin" => "asdf", "cos" => "cos"]; default = "cos")
     @test default(el) == "cos"
 
+    hrd(x) = occursin("<details", repr(MIME"text/html"(), x))
 
-
-
-
+    @test hrd(details("a", "b"))
+    @test hrd(details("a", ("b","c"); open=true))
+    @test hrd(details("a", [md"b", Slider(1:10)]; open=true))
 
     el = Slider(0.0:π:20)
     @test default(el) == 0


### PR DESCRIPTION
Adds new function `details` to automatically create a well formed [Details disclosure element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) (`<details>`).

Currently scoped as:

~~using PlutoUI.ExperimentalLayout: details~~

```julia
using PlutoUI #: details
```

![Example usage of new details function](https://github.com/JuliaPluto/PlutoUI.jl/assets/11425944/d28c0aa2-5207-48ee-9515-dfb33d3ae195)

Since this new function creates normal HTML `<details>` elements, collapsed details elements will omit their contents from any print/export. If this behavior is undesirable, it seems a JS fix could be applied as discussed [here on SO](https://stackoverflow.com/questions/19646684/force-open-the-details-summary-tag-for-print-in-chrome#answer-75260733) though I'm unsure where it would slot in.

I couldn't get `@bind` to behave properly in the Layout.jl notebook to fully test it internally. UI elements would render, but bound variables would never update. When using `details` in the binder environment automatically created by github-actions it behaves as expected.

![Example usage of new details function with bound variables](https://github.com/JuliaPluto/PlutoUI.jl/assets/11425944/dd521e91-7039-43fc-b24c-6f65c078d56a)
