### PR TITLE
Lift `AbstractString` type restriction on `summary` arg of `details`

### DIFF
--- a/src/Details.jl
+++ b/src/Details.jl
@@ -88,6 +88,7 @@ plutoui-detail:last-child {
 
 pluto-output div.summary-title-outer {
 	display: inline-flex;
+	vertical-align: text-top;
 	width: calc(100% - 1em);
 	margin-left: -1em;
 	padding-left: 1em;

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.38
+# v0.19.40
 
 using Markdown
 using InteractiveUtils
@@ -86,11 +86,15 @@ plutoui-detail:last-child {
 	margin-block-end: 0;
 }
 
-pluto-output div.summary-title {
-	display: inline-block;
+pluto-output div.summary-title-outer {
+	display: inline-flex;
 	width: calc(100% - 1em);
 	margin-left: -1em;
 	padding-left: 1em;
+}
+
+pluto-output div.summary-title-outer > div.summary-title-inner {
+	display: inline-block;
 }
 </style>
 """)
@@ -100,7 +104,13 @@ const Iterable = Union{AbstractVector, Tuple, Base.Generator}
 
 # ╔═╡ 46521e2b-ea06-491a-9842-13dff7dc8299
 begin
-	embed_summary(summary) = @htl("<div class='summary-title'>$(summary)</div>")
+	embed_summary(summary) = @htl("""
+		<div class='summary-title-outer'>
+			<div class='summary-title-inner'>
+				$(summary)
+			</div>
+		</div>
+		""")
 	embed_summary(summary::AbstractString) = summary
 
 	embed_detail(detail) = isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display) ?
@@ -282,6 +292,18 @@ details(md"This is a very long markdown summary to make sure everything is hunky
 # ╔═╡ 5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 export details
 
+# ╔═╡ 1a6003f5-0157-43cb-9316-bbdf9fccb438
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details(md"_I'm_ **going** _to_ **take** _over_ **the world!** _Would_ **you** _like_ **to** _know_ **more?** _Let's_ **make** _this_ **even** _longer_ **to** _check_ **how** _everything_ **wraps.**", "arst", open=true)
+  ╠═╡ =#
+
+# ╔═╡ 0bc0b59e-a84f-465a-9397-9d81db09a3b6
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details(htl"<em>I'm</em> <b>going</b> <em>to</em> <b>take</b> <em>over</em> <b>the world!</b> <em>Would</em> <b>you</b> <em>like</em> <b>to</b> <em>know</em> <b>more?</b> <em>Let's</em> <b>make</b> <em>this</em> <b>even</b> <em>longer</em> <b>to</b> <em>check</em> <b>how</b> <em>everything</em> <b>wraps.</b>", "arst", open=true)
+  ╠═╡ =#
+
 # ╔═╡ Cell order:
 # ╠═81f5b495-76c4-4c54-93ab-b49c5ecb810a
 # ╠═b7b18a54-afd7-4467-83ed-cc4f07c321fb
@@ -298,5 +320,7 @@ export details
 # ╠═f18bf0a3-e59b-45d4-b8b1-5404145db44e
 # ╠═5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 # ╠═13e81634-3b72-4b1d-a89b-36d184698d21
+# ╠═1a6003f5-0157-43cb-9316-bbdf9fccb438
+# ╠═0bc0b59e-a84f-465a-9397-9d81db09a3b6
 # ╟─df840588-23bd-4b03-b5ab-ef273052d198
 # ╠═46521e2b-ea06-491a-9842-13dff7dc8299

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -85,6 +85,13 @@ plutoui-detail {
 plutoui-detail:last-child {
 	margin-block-end: 0;
 }
+
+pluto-output div.summary-title {
+	display: inline-block;
+	width: 100%;
+	margin-left: -1em;
+	padding-left: 1em;
+}
 </style>
 """)
 
@@ -93,13 +100,18 @@ const Iterable = Union{AbstractVector, Tuple, Base.Generator}
 
 # ╔═╡ 46521e2b-ea06-491a-9842-13dff7dc8299
 begin
-	embed_detail(x) = isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display) ? Main.PlutoRunner.embed_display(x) : x
-	embed_detail(x::AbstractString) = x
+	embed_summary(summary) = @htl("<div class='summary-title'>$(summary)</div>")
+	embed_summary(summary::AbstractString) = summary
+
+	embed_detail(detail) = isdefined(Main, :PlutoRunner) && isdefined(Main.PlutoRunner, :embed_display) ?
+		Main.PlutoRunner.embed_display(detail) :
+		detail
+	embed_detail(detail::AbstractString) = detail
 	
-	function details(summary::AbstractString, contents::Iterable; open::Bool=false)
+	function details(summary, contents::Iterable; open::Bool=false)
 		@htl("""
 		<details $(open ? (open=true,) : nothing)>
-			<summary>$(summary)</summary>
+			<summary>$(embed_summary(summary))</summary>
 			<div class="details-content">
 				$(Iterators.map(contents) do detail
 					@htl("<plutoui-detail>$(embed_detail(detail))</plutoui-detail>")
@@ -111,11 +123,11 @@ begin
 	end
 
 	# Convenience function for when you just provide a single detail
-	details(summary::AbstractString, contents; open::Bool=false) = details(summary, (contents,); open)
+	details(summary, contents; open::Bool=false) = details(summary, (contents,); open)
 
 	"""
 	```julia
-	details(summary::AbstractString, contents; open::Bool=false)
+	details(summary, contents; open::Bool=false)
 	```
 	
 	Create a collapsable details disclosure element (`<details>`).
@@ -124,7 +136,7 @@ begin
 	
 	# Arguments
 	
-	- `summary::AbstractString`: the always visible summary of the details element.
+	- `summary::Any`: the always visible summary of the details element.
 	- `contents::Any`: the item(s) to nest within the details element.
 	
 	# Keyword arguments
@@ -171,20 +183,19 @@ end
 #=╠═╡
 begin
 	my_details = details(
-		"I'm going to take over the world! Would you like to know more?", 
+		htl"I'm going to take over <u>the world!</u> Would you like to know more?", 
 		[
-			"I'm going to start small",
-			"I'm going to start small",
-			"I'm going to start small",
-			md"#### But don't mark me down just yet!",
+			htl"<small>I'm going to start small</small>",
+			"But not too small, mind you",
+			htl"<big>Don't mark me down!</big>", # Even funnier now that this isn't md
 			md"""
-			Here are my steps for world domination! 🌍
+			## Here are my steps for world domination! 🌍
 			- Perfect my **evil laugh** 🦹
 			- Create **_Laser (Pointer) of Doom_™** ⚡
 			- Train **ninja cats** 🥷🐈
 			- Build **volcanic lair** 🌋
 			""",
-			@htl("<p>Fantastic!</p>"),
+			@htl("<p style='font-variant: small-caps'>fantastic!</p>"),
 			["Cat", "Laser (Pointer) ", "Volcano"],
 			Dict(
 				:cat => "Fluffy",
@@ -205,19 +216,19 @@ end
 # ╔═╡ b8434c11-2bb5-47ba-8562-e1176cba0af7
 # ╠═╡ skip_as_script = true
 #=╠═╡
-details("hello", "asdf")
+details("# Hello!", "**How are you?**")
   ╠═╡ =#
 
 # ╔═╡ f833a0bf-f7f7-417d-8cd9-5f93a90aecf6
 # ╠═╡ skip_as_script = true
 #=╠═╡
-details("hello", "asdf"; open=true)
+details("# Hello!", "**How are you?**"; open=true)
   ╠═╡ =#
 
 # ╔═╡ ef3ebb39-03ce-407b-9796-cae10d88f4a0
 # ╠═╡ skip_as_script = true
 #=╠═╡
-details("hello", md"asdf"; open=true)
+details(md"# Hello!", md"**How are you?**"; open=true)
   ╠═╡ =#
 
 # ╔═╡ b7349133-2590-415c-9a11-15c85e897a5c
@@ -244,6 +255,16 @@ my_var
 feeling
   ╠═╡ =#
 
+# ╔═╡ ffb735cd-a98e-4e98-909e-4d7e9f2dec5e
+begin
+	bad_summary = Dict(
+		:a => "A",
+		:b => "B",
+	)
+	
+	details(bad_summary, "asdf")
+end
+
 # ╔═╡ 5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 export details
 
@@ -258,6 +279,7 @@ export details
 # ╠═b7349133-2590-415c-9a11-15c85e897a5c
 # ╠═a5663932-9a19-4d6d-9b20-d6fefac8cf9d
 # ╠═cd2bcfa2-5759-40d6-9358-3e7e605c5bc2
+# ╠═ffb735cd-a98e-4e98-909e-4d7e9f2dec5e
 # ╠═5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 # ╠═13e81634-3b72-4b1d-a89b-36d184698d21
 # ╟─df840588-23bd-4b03-b5ab-ef273052d198

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -88,7 +88,7 @@ plutoui-detail:last-child {
 
 pluto-output div.summary-title {
 	display: inline-block;
-	width: 100%;
+	width: calc(100% - 1em);
 	margin-left: -1em;
 	padding-left: 1em;
 }
@@ -273,6 +273,12 @@ begin
 end
   ╠═╡ =#
 
+# ╔═╡ f18bf0a3-e59b-45d4-b8b1-5404145db44e
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details(md"This is a very long markdown summary to make sure everything is hunky-dory :)", "arst"; open=true)
+  ╠═╡ =#
+
 # ╔═╡ 5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 export details
 
@@ -289,6 +295,7 @@ export details
 # ╠═a5663932-9a19-4d6d-9b20-d6fefac8cf9d
 # ╠═cd2bcfa2-5759-40d6-9358-3e7e605c5bc2
 # ╠═ffb735cd-a98e-4e98-909e-4d7e9f2dec5e
+# ╠═f18bf0a3-e59b-45d4-b8b1-5404145db44e
 # ╠═5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 # ╠═13e81634-3b72-4b1d-a89b-36d184698d21
 # ╟─df840588-23bd-4b03-b5ab-ef273052d198

--- a/src/Details.jl
+++ b/src/Details.jl
@@ -231,6 +231,12 @@ details("# Hello!", "**How are you?**"; open=true)
 details(md"# Hello!", md"**How are you?**"; open=true)
   ╠═╡ =#
 
+# ╔═╡ 2f3bc9f1-3055-465a-8a29-792969279e06
+# ╠═╡ skip_as_script = true
+#=╠═╡
+details(htl"<h1>Hello!</h1>", md"**How are you?**"; open=true)
+  ╠═╡ =#
+
 # ╔═╡ b7349133-2590-415c-9a11-15c85e897a5c
 # ╠═╡ skip_as_script = true
 #=╠═╡
@@ -256,14 +262,16 @@ feeling
   ╠═╡ =#
 
 # ╔═╡ ffb735cd-a98e-4e98-909e-4d7e9f2dec5e
+# ╠═╡ skip_as_script = true
+#=╠═╡
 begin
 	bad_summary = Dict(
 		:a => "A",
 		:b => "B",
 	)
-	
-	details(bad_summary, "asdf")
+	details(bad_summary, "Why have you done this?"; open=true)
 end
+  ╠═╡ =#
 
 # ╔═╡ 5d28fa36-49dc-4d0f-a1c3-3fc2a5efdd0a
 export details
@@ -275,6 +283,7 @@ export details
 # ╠═b8434c11-2bb5-47ba-8562-e1176cba0af7
 # ╠═f833a0bf-f7f7-417d-8cd9-5f93a90aecf6
 # ╠═ef3ebb39-03ce-407b-9796-cae10d88f4a0
+# ╠═2f3bc9f1-3055-465a-8a29-792969279e06
 # ╠═b3732e34-d331-4dd2-b4fb-11b2f397d7c1
 # ╠═b7349133-2590-415c-9a11-15c85e897a5c
 # ╠═a5663932-9a19-4d6d-9b20-d6fefac8cf9d


### PR DESCRIPTION
Fixes: https://github.com/JuliaPluto/PlutoUI.jl/issues/295

Allows any type to be used as `summary` and leaves it up to the user to decide what is rational.

Unlike the `details` argument, `summary` is **not** embedded using `embed_display`. Instead `summary` is only wrapped by a simple `div` with appropriate CSS to provide a decent display for html-like objects.

## Examples

| `summary` type | Output |
| --- | --- |
| String (unchanged) | ![image](https://github.com/JuliaPluto/PlutoUI.jl/assets/11425944/91de4aeb-f897-42aa-9df6-55f95fc0fac1) |
| `@md` | ![image](https://github.com/JuliaPluto/PlutoUI.jl/assets/11425944/865a33b0-b93c-4b47-8b8c-1ea782336203) |
| `@htl` | ![image](https://github.com/JuliaPluto/PlutoUI.jl/assets/11425944/d3b9fdd4-42a5-402e-93fb-416f1168128b) |
| other (dict) | ![image](https://github.com/JuliaPluto/PlutoUI.jl/assets/11425944/923bbad5-086f-4708-8823-27ea0ab9f1f1) |