### PR TITLE
[WIP] Getting data from local resource

### DIFF
--- a/src/Resource.jl
+++ b/src/Resource.jl
@@ -101,6 +101,8 @@ function LocalResource(path::AbstractString, html_attributes::Pair...)
 	Resource(src, mime, html_attributes)
 end
 
+Vector{UInt8}(r::PlutoUI.Resource) = Base64.base64decode(split(r.src, ',', limit=2) |> last)
+
 ###
 # DOWNLOAD BUTTON
 ###

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,8 +129,9 @@ end
         occursin("https://asdf.com/a/b/c.mp4?b=23f&amp;c=asdf.png", h4)
     )
     @test occursin(r"asdf=[\'\"]123px", h5)
-    
-        
+    @test Vector{UInt8}(r3) == Vector{UInt8}("asdf")
+
+
 end
 
 @testset "DownloadButton" begin


### PR DESCRIPTION
What is the best way to get data from a `LocalResource`?

For my application, I am treating a Pluto notebook just like a Julia script, and am packaging it alongside some data that is being analyzed. The files are small-medium size, so the `data:` URI technique employed by this package is an ideal fit for export to HTML later.

One of the files is a `.csv` file, and I need to parse it. Currently, I am doing something like this with the help of a new method currently in this PR as a straw-man:

```julia
f = PlutoUI.LocalResource("data.csv")
d = CSV.read(Vector{UInt8}(f), DataFrame)
```

(One problem with this approach is that it will only work for `Resource`s that are generated using the `LocalResource` function; perhaps the type should be forked?)

Happy to implement something and propose it here, but I am wondering if there are better ways to do what I am trying to do. Ideas:

1. integrate with the [FileIO.jl](https://github.com/JuliaIO/FileIO.jl) package
2. use the [`PlutoUI.as_text` function](https://github.com/JuliaPluto/PlutoUI.jl/blob/a493709f9201c61e17585fdcc2cd0c4dc95321f5/src/DisplayTricks.jl#L23) in a way I don't yet understand
3. use something like the [RelocatableFolders.jl](https://github.com/JuliaPackaging/RelocatableFolders.jl) package ([a la PackageCompiler](https://julialang.github.io/PackageCompiler.jl/stable/apps.html#relocatability))
4. use another approach not involving `LocalResource` - e.g. if it is going to be deprecated or externalized in the future