### PR TITLE
New macro `@bindname` to display variable name before bond

### DIFF
--- a/src/PlutoUI.jl
+++ b/src/PlutoUI.jl
@@ -79,5 +79,6 @@ end
 
 
 include("./ScrubbableMatrix.jl")
+include("./bindname.jl")
 
 end

--- a/src/bindname.jl
+++ b/src/bindname.jl
@@ -1,0 +1,35 @@
+import HypertextLiteral
+
+"""
+```julia
+@bindname name Slider(1:10)
+```
+
+Like `@bind` in Pluto, but it also displays the name of the variable before the input widget.
+"""
+macro bindname(name::Symbol, ex::Expr)
+    
+    # Some macro magic to call the `@bind` macro without hygiene. This will use whatever `@bind` is defined in the scope of the caller of this macro.
+    # We could just do `Main.PlutoRunner.@bind`, but then if you run the notebook.jl as a standalone script, it does not find the mock `@bind`.
+    bindcall = Expr(:macrocall, 
+        Symbol("@bind"),
+        __source__,
+        name,
+        ex
+    )
+    
+    # Messy HTML to avoid unintended whitespace, which can show up in rare cases.
+    quote
+        bond = $(esc(bindcall))
+        
+        HypertextLiteral.@htl(
+            """<div style='display: flex; flex-wrap: wrap; align-items: baseline;'><code style='color: var(--cm-color-var) !important; font-weight: 700;'>$(
+                $(String(name))
+            )&nbsp<span style="opacity: .6">=</span>&nbsp</code>$(
+                bond
+            )</div>"""
+        )
+    end
+end
+
+export @bindname


### PR DESCRIPTION
This PR makes a macro `@bindname` available when you do `using PlutoUI`.

<img width="281" alt="image" src="https://github.com/user-attachments/assets/92863330-31ce-4157-9b05-980dbba474a4">

This solves a common pattern: writing the variable name by hand in markdown, and then interpolating the `@bind` call. See e.g. https://discourse.julialang.org/t/current-maintained-interactive-julia-gui-system-mid-2024/118318/11?u=fonsp



The styling matches exactly that of a variable declaration.


This will also still work in a standalone file without Pluto:

<img width="392" alt="image" src="https://github.com/user-attachments/assets/0467e813-849e-4ba8-a6bb-b370ca81be4c">

<img width="289" alt="Scherm­afbeelding 2024-08-25 om 09 55 54" src="https://github.com/user-attachments/assets/ed085d64-4a71-4f37-a90f-f88c3b5bc5f8">


